### PR TITLE
Add tests, interface, and two concrete implementations for RetryPolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ bazel-*
 .idea/
 cmake-build-*/
 
+# Tags
+GPATH
+GRTAGS
+GTAGS
+TAGS

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2019 Google Inc.  All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+cc_library(
+    name = "gax",
+    srcs = [],
+    hdrs = [
+        "retry_policy.h",
+    ],
+    deps = [
+    ],
+)
+
+gax_unit_tests = [
+    "retry_policy_unittest.cc",
+]
+
+[cc_test(
+    name = "gax_" + test.replace(".cc", ""),
+    size = "small",
+    srcs = [test],
+    deps = [
+        "//gax",
+        "@gtest//:gtest_main",
+    ],
+) for test in gax_unit_tests]

--- a/gax/retry_policy.h
+++ b/gax/retry_policy.h
@@ -1,0 +1,117 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_GAX_RETRY_POLICY_H_
+#define GOOGLE_GAX_RETRY_POLICY_H_
+
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace gax {
+
+/**
+ * Define the interface for controlling how clients retry RPC operations.
+ *
+ * Idempotent (and certain non-idempotent) operations can be retried
+ * transparently to the user. However, we need to give the users enough flexiblity
+ * to control when to stop retrying.
+ *
+ * The application provides an instance of this class when the client is created.
+ */
+template <typename StatusType, typename RetryablePolicy>
+class RetryPolicy {
+ public:
+  virtual ~RetryPolicy() = default;
+
+  /**
+   * Return a new copy of this object with the same retry criteria and fresh state.
+   */
+  virtual std::unique_ptr<RetryPolicy<StatusType, RetryablePolicy>> clone() const = 0;
+
+  /**
+   * Handle an RPC failure
+   *
+   * @return true if the RPC operation should be retried.
+   */
+  virtual bool OnFailure(StatusType const& status) = 0;
+};
+
+/**
+ * Implement a simple "count errors and then stop" retry policy.
+ */
+template <typename StatusType, typename RetryablePolicy>
+class LimitedErrorCountRetryPolicy : RetryPolicy<StatusType, RetryablePolicy> {
+  using BaseType = RetryPolicy<StatusType, RetryablePolicy>;
+
+ public:
+  LimitedErrorCountRetryPolicy(int max_failures)
+      : failure_count_(0), max_failures_(max_failures) {}
+
+  LimitedErrorCountRetryPolicy(LimitedErrorCountRetryPolicy const& rhs) noexcept
+      : LimitedErrorCountRetryPolicy(rhs.max_failures_) {}
+
+  LimitedErrorCountRetryPolicy(LimitedErrorCountRetryPolicy&& rhs) noexcept
+      : LimitedErrorCountRetryPolicy(rhs.max_failures_) {}
+
+  std::unique_ptr<RetryPolicy<StatusType, RetryablePolicy>> clone() const override {
+    return std::unique_ptr<BaseType>(new LimitedErrorCountRetryPolicy<StatusType, RetryablePolicy>(*this));
+  }
+
+  bool OnFailure(StatusType const& status) override {
+    return (!RetryablePolicy::IsPermanentFailure(status) &&
+            (failure_count_++) < max_failures_);
+  }
+
+ private:
+  int failure_count_;
+  int const max_failures_;
+};
+
+/**
+ * Implement a simple "keep trying for this time" retry policy.
+ */
+template <typename StatusType, typename RetryablePolicy, typename Clock>
+class LimitedDurationRetryPolicy : RetryPolicy<StatusType, RetryablePolicy> {
+  using BaseType = RetryPolicy<StatusType, RetryablePolicy>;
+
+ public:
+  template <typename duration_t>
+  LimitedDurationRetryPolicy(duration_t max_duration) : max_duration_(max_duration),
+                                                        deadline_(max_duration_ + Clock::now()) {}
+
+  LimitedDurationRetryPolicy(LimitedDurationRetryPolicy const& rhs) noexcept
+      : LimitedDurationRetryPolicy(rhs.max_duration_) {}
+
+  LimitedDurationRetryPolicy(LimitedDurationRetryPolicy&& rhs) noexcept
+      : LimitedDurationRetryPolicy(rhs.max_duration_) {}
+
+  std::unique_ptr<RetryPolicy<StatusType, RetryablePolicy>> clone() const override {
+    return std::unique_ptr<BaseType>(new LimitedDurationRetryPolicy<StatusType, RetryablePolicy, Clock>(*this));
+  }
+
+  bool OnFailure(StatusType const & status) override {
+    return (!RetryablePolicy::IsPermanentFailure(status) &&
+            Clock::now() < deadline_);
+  }
+
+ private:
+  std::chrono::milliseconds const max_duration_;
+  std::chrono::system_clock::time_point const deadline_;
+};
+
+}  // namespace gax
+}  // namespace google
+
+#endif  // GOOGLE_GAX_RETRY_POLICY_H_

--- a/gax/retry_policy_unittest.cc
+++ b/gax/retry_policy_unittest.cc
@@ -1,0 +1,163 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "googletest/include/gtest/gtest.h"
+#include "retry_policy.h"
+#include <chrono>
+#include <memory>
+
+namespace {
+using namespace ::google;
+
+class TestStatus {
+ public:
+  bool const isPermanent;
+};
+
+class TestRetryablePolicy {
+ public:
+  static bool IsPermanentFailure(TestStatus const& s) {
+    return s.isPermanent;
+  }
+};
+
+using RP = gax::RetryPolicy<TestStatus, TestRetryablePolicy>;
+
+using LECRP = gax::LimitedErrorCountRetryPolicy<TestStatus, TestRetryablePolicy>;
+
+TEST(LimitedErrorCountRetryPolicy, Basic) {
+  LECRP tested(3);
+  TestStatus s{false};
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_FALSE(tested.OnFailure(s));
+  EXPECT_FALSE(tested.OnFailure(s));
+}
+
+TEST(LimitedErrorCountRetryPolicy, PermanentFailureCheck) {
+  LECRP tested(3);
+  TestStatus s{true};
+  EXPECT_FALSE(tested.OnFailure(s));
+}
+
+TEST(LimitedErrorCountRetryPolicy, CopyConstruct) {
+  LECRP tested(3);
+  TestStatus s{false};
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  LECRP copy(tested);
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_FALSE(copy.OnFailure(s));
+}
+
+TEST(LimitedErrorCountRetryPolicy, MoveConstruct) {
+  LECRP tested(3);
+  TestStatus s{false};
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  LECRP copy(std::move(tested));
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_TRUE(copy.OnFailure(s));
+  EXPECT_FALSE(copy.OnFailure(s));
+}
+
+TEST(LimitedErrorCountRetryPolicy, Clone) {
+  LECRP tested(3);
+  TestStatus s{false};
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_TRUE(tested.OnFailure(s));
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  std::unique_ptr<RP> clone = tested.clone();
+  EXPECT_TRUE(clone->OnFailure(s));
+  EXPECT_TRUE(clone->OnFailure(s));
+  EXPECT_TRUE(clone->OnFailure(s));
+  EXPECT_FALSE(clone->OnFailure(s));
+}
+
+static std::chrono::time_point<std::chrono::system_clock> now_point = std::chrono::system_clock::now();
+
+class TestClock {
+ public:
+  static inline std::chrono::time_point<std::chrono::system_clock> now() {
+    return now_point;
+  }
+};
+
+using LDRP = gax::LimitedDurationRetryPolicy<TestStatus, TestRetryablePolicy, TestClock>;
+
+TEST(LimitedDurationRetryPolicy, Basic) {
+  LDRP tested(std::chrono::milliseconds(5));
+  TestStatus s{false};
+  EXPECT_TRUE(tested.OnFailure(s));
+
+  now_point += std::chrono::milliseconds(2);
+  EXPECT_TRUE(tested.OnFailure(s));
+
+  now_point += std::chrono::milliseconds(10);
+  EXPECT_FALSE(tested.OnFailure(s));
+}
+
+TEST(LimitedDurationRetryPolicy, PermanentFailureCheck) {
+  LDRP tested(std::chrono::milliseconds(5));
+  TestStatus s{true};
+
+  EXPECT_FALSE(tested.OnFailure(s));
+}
+
+TEST(LimitedDurationRetryPolicy, CopyConstruct) {
+  LDRP tested(std::chrono::milliseconds(5));
+  TestStatus s{false};
+
+  now_point += std::chrono::milliseconds(10);
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  LDRP copy(tested);
+  EXPECT_TRUE(copy.OnFailure(s));
+}
+
+TEST(LimitedDurationRetryPolicy, MoveConstruct) {
+  LDRP tested(std::chrono::milliseconds(5));
+  TestStatus s{false};
+
+  now_point += std::chrono::milliseconds(10);
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  LDRP copy(std::move(tested));
+  EXPECT_TRUE(copy.OnFailure(s));
+}
+
+TEST(LimitedDurationRetryPolicy, Clone) {
+  LDRP tested(std::chrono::milliseconds(5));
+  TestStatus s{false};
+
+  now_point += std::chrono::milliseconds(10);
+  EXPECT_FALSE(tested.OnFailure(s));
+
+  std::unique_ptr<RP> clone = tested.clone();
+  EXPECT_TRUE(clone->OnFailure(s));
+}
+
+}  // namespace


### PR DESCRIPTION
Clients are expected to retry idempotent (and some non-idempotent)
rpcs that fail. Clients can configure this behavior via policy
objects.
Objects that follow the RetryPolicy interface take a non-success
status code and, based on some internal state, indicate whether the
operation should be retried.