### PR TITLE
Add implementation and tests for gax::Status

### DIFF
--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -18,9 +18,12 @@ licenses(["notice"])  # Apache 2.0
 
 cc_library(
     name = "gax",
-    srcs = [],
+    srcs = [
+        "status.cc",
+    ],
     hdrs = [
         "retry_policy.h",
+        "status.h",
     ],
     deps = [
     ],
@@ -28,6 +31,7 @@ cc_library(
 
 gax_unit_tests = [
     "retry_policy_unittest.cc",
+    "status_unittest.cc",
 ]
 
 [cc_test(

--- a/gax/status.cc
+++ b/gax/status.cc
@@ -1,0 +1,73 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ostream>
+#include <string>
+
+#include "status.h"
+
+namespace google {
+namespace gax {
+
+std::string StatusCodeToString(StatusCode code) {
+  switch (code) {
+    case StatusCode::kOk:
+      return "OK";
+    case StatusCode::kCancelled:
+      return "CANCELLED";
+    case StatusCode::kUnknown:
+      return "UNKNOWN";
+    case StatusCode::kInvalidArgument:
+      return "INVALID_ARGUMENT";
+    case StatusCode::kDeadlineExceeded:
+      return "DEADLINE_EXCEEDED";
+    case StatusCode::kNotFound:
+      return "NOT_FOUND";
+    case StatusCode::kAlreadyExists:
+      return "ALREADY_EXISTS";
+    case StatusCode::kPermissionDenied:
+      return "PERMISSION_DENIED";
+    case StatusCode::kResourceExhausted:
+      return "RESOURCE_EXHAUSTED";
+    case StatusCode::kFailedPrecondition:
+      return "FAILED_PRECONDITION";
+    case StatusCode::kAborted:
+      return "ABORTED";
+    case StatusCode::kOutOfRange:
+      return "OUT_OF_RANGE";
+    case StatusCode::kUnimplemented:
+      return "UNIMPLEMENTED";
+    case StatusCode::kInternal:
+      return "INTERNAL";
+    case StatusCode::kUnavailable:
+      return "UNAVAILABLE";
+    case StatusCode::kDataLoss:
+      return "DATA_LOSS";
+    case StatusCode::kUnauthenticated:
+      return "UNAUTHENTICATED";
+    default:
+      return "UNEXPECTED_STATUS_CODE=" + std::to_string(static_cast<int>(code));
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, StatusCode code){
+  return os << StatusCodeToString(code);
+}
+
+std::ostream& operator<<(std::ostream& os, Status const& rhs) {
+  return os << rhs.message() << " [" << rhs.code() << "]";
+}
+
+}  // namespace gax
+}  // namespace google

--- a/gax/status.h
+++ b/gax/status.h
@@ -21,6 +21,11 @@
 namespace google {
 namespace gax {
 
+/**
+ * The underlying StatusCode is intended to closely resemble
+ * grpc::StatusCode, the semantics of which are documented in:
+ *    https://grpc.io/grpc/cpp/classgrpc_1_1_status.html
+ */
 enum class StatusCode {
   /// Not an error; returned on success.
   kOk = 0,
@@ -43,6 +48,12 @@ enum class StatusCode {
   kUnauthenticated = 16,
 };
 
+/**
+ * Reports error code and details from a remote request.
+ *
+ * This class is modeled after `grpc::Status`.
+ * It contains the status code and error message(if applicable) from an RPC.
+ */
 class Status {
  public:
   Status() : code_(StatusCode::kOk) {}

--- a/gax/status.h
+++ b/gax/status.h
@@ -1,0 +1,81 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_GAX_STATUS_H_
+#define GOOGLE_GAX_STATUS_H_
+
+#include <ostream>
+#include <string>
+
+namespace google {
+namespace gax {
+
+enum class StatusCode {
+  /// Not an error; returned on success.
+  kOk = 0,
+
+  kCancelled = 1,
+  kUnknown = 2,
+  kInvalidArgument = 3,
+  kDeadlineExceeded = 4,
+  kNotFound = 5,
+  kAlreadyExists = 6,
+  kPermissionDenied = 7,
+  kResourceExhausted = 8,
+  kFailedPrecondition = 9,
+  kAborted = 10,
+  kOutOfRange = 11,
+  kUnimplemented = 12,
+  kInternal = 13,
+  kUnavailable = 14,
+  kDataLoss = 15,
+  kUnauthenticated = 16,
+};
+
+class Status {
+ public:
+  Status() : code_(StatusCode::kOk) {}
+  explicit Status(StatusCode code, std::string msg) : code_(code),
+                                                      msg_(std::move(msg)) {}
+
+  inline bool IsOk() const { return code_ == StatusCode::kOk; }
+  inline bool IsTransientFailure() const {
+    return (code_ == StatusCode::kAborted ||
+            code_ == StatusCode::kUnavailable ||
+            code_ == StatusCode::kDeadlineExceeded);
+  }
+  inline bool IsPermanentFailure() const { return !IsOk() && !IsTransientFailure(); }
+
+  inline StatusCode code() const { return code_; }
+
+  inline std::string const& message() const { return msg_; }
+
+  bool operator==(Status const& rhs) const {
+    return code_ == rhs.code_ && msg_ == rhs.msg_;
+  }
+  bool operator!=(Status const& rhs) const { return !(*this == rhs); }
+
+ private:
+  StatusCode const code_;
+  std::string const msg_;
+};
+
+std::string StatusCodeToString(StatusCode code);
+std::ostream& operator<<(std::ostream& os, StatusCode code);
+std::ostream& operator<<(std::ostream& os, Status const& rhs);
+
+}  // namespace gax
+}  // namespace google
+
+#endif  // GOOGLE_GAX_RETRY_POLICY_H_

--- a/gax/status_unittest.cc
+++ b/gax/status_unittest.cc
@@ -22,7 +22,7 @@ namespace {
 
 using namespace ::google;
 
-TEST(Status,Basic){
+TEST(Status,Basic) {
   {
     gax::Status s;  // sanity check for default construction
     EXPECT_TRUE(s.IsOk());
@@ -105,7 +105,7 @@ TEST(Status,Basic){
   }
 }
 
-TEST(Status,CodeOstream){
+TEST(Status,CodeOstream) {
   std::ostringstream output;
 
   output << gax::StatusCode::kOk;

--- a/gax/status_unittest.cc
+++ b/gax/status_unittest.cc
@@ -1,0 +1,217 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "googletest/include/gtest/gtest.h"
+#include "status.h"
+
+#include <sstream>
+#include <string>
+
+namespace {
+
+using namespace ::google;
+
+TEST(Status,Basic){
+  {
+    gax::Status s;  // sanity check for default construction
+    EXPECT_TRUE(s.IsOk());
+    EXPECT_FALSE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kCancelled, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kInvalidArgument, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kDeadlineExceeded, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_FALSE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kNotFound, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kAlreadyExists, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kPermissionDenied, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kUnauthenticated, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kResourceExhausted, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kFailedPrecondition, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kAborted, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_FALSE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kOutOfRange, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kUnimplemented, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kInternal, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kUnavailable, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_FALSE(s.IsPermanentFailure());
+  }
+  {
+    gax::Status s(gax::StatusCode::kDataLoss, "");
+    EXPECT_FALSE(s.IsOk());
+    EXPECT_TRUE(s.IsPermanentFailure());
+  }
+}
+
+TEST(Status,CodeOstream){
+  std::ostringstream output;
+
+  output << gax::StatusCode::kOk;
+  EXPECT_EQ("OK", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kCancelled;
+  EXPECT_EQ("CANCELLED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kUnknown;
+  EXPECT_EQ("UNKNOWN", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kInvalidArgument;
+  EXPECT_EQ("INVALID_ARGUMENT", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kDeadlineExceeded;
+  EXPECT_EQ("DEADLINE_EXCEEDED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kNotFound;
+  EXPECT_EQ("NOT_FOUND", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kAlreadyExists;
+  EXPECT_EQ("ALREADY_EXISTS", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kPermissionDenied;
+  EXPECT_EQ("PERMISSION_DENIED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kResourceExhausted;
+  EXPECT_EQ("RESOURCE_EXHAUSTED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kFailedPrecondition;
+  EXPECT_EQ("FAILED_PRECONDITION", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kAborted;
+  EXPECT_EQ("ABORTED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kOutOfRange;
+  EXPECT_EQ("OUT_OF_RANGE", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kUnimplemented;
+  EXPECT_EQ("UNIMPLEMENTED", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kInternal;
+  EXPECT_EQ("INTERNAL", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kUnavailable;
+  EXPECT_EQ("UNAVAILABLE", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kDataLoss;
+  EXPECT_EQ("DATA_LOSS", output.str());
+
+  output = std::ostringstream();
+  output << gax::StatusCode::kUnauthenticated;
+  EXPECT_EQ("UNAUTHENTICATED", output.str());
+
+  output = std::ostringstream();
+  output << static_cast<gax::StatusCode>(42);
+  EXPECT_EQ("UNEXPECTED_STATUS_CODE=42", output.str());
+}
+
+TEST(Status,Ostream) {
+  {
+    std::ostringstream output;
+    gax::Status s;
+
+    output << s;
+    EXPECT_EQ(" [OK]", output.str());
+  }
+
+  {
+    std::ostringstream output;
+    gax::Status s(gax::StatusCode::kCancelled, "Because");
+    output << s;
+    EXPECT_EQ("Because [CANCELLED]", output.str());
+  }
+}
+
+TEST(Status,Equality) {
+  gax::Status ok1, ok2;
+  EXPECT_EQ(ok1, ok2);
+
+  gax::Status ok3(gax::StatusCode::kOk, "");
+  EXPECT_EQ(ok1, ok3);
+
+  gax::Status ok4(gax::StatusCode::kOk, "Because");
+  EXPECT_NE(ok1, ok4);
+
+  gax::Status cancelled1(gax::StatusCode::kCancelled, "");
+  EXPECT_NE(ok1, cancelled1);
+
+  gax::Status cancelled2(gax::StatusCode::kCancelled, "Because");
+  EXPECT_NE(ok1, cancelled2);
+}
+
+}  // namespace


### PR DESCRIPTION
The gax::Status type is intended to be a cornerstone of the client
library. It will be a part of the eventual StatusOr template type,
and is used to determine retryability of failed operations.

The type is default constructable, compares equality, defines
operator<<, and provides convenience query methods for its component attributes.

The underlying StatusCode is intended to closely resemble
grpc::StatusCode, the semantics of which are documented in:
https://grpc.io/grpc/cpp/classgrpc_1_1_status.html

Includes tweaks to RetryPolicy and associated tests to remove
templating and to instead concretely depend on gax::Status.