### PR TITLE
Tests, abstract interface, and concrete implementation for BackoffPolicy

### DIFF
--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -24,6 +24,7 @@ cc_library(
     ],
     hdrs = [
         "backoff_policy.h",
+        "internal/gtest_prod.h",
         "retry_policy.h",
         "status.h",
     ],

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -19,9 +19,11 @@ licenses(["notice"])  # Apache 2.0
 cc_library(
     name = "gax",
     srcs = [
+        "backoff_policy.cc",
         "status.cc",
     ],
     hdrs = [
+        "backoff_policy.h",
         "retry_policy.h",
         "status.h",
     ],
@@ -30,6 +32,7 @@ cc_library(
 )
 
 gax_unit_tests = [
+    "backoff_policy_unittest.cc",
     "retry_policy_unittest.cc",
     "status_unittest.cc",
 ]

--- a/gax/backoff_policy.cc
+++ b/gax/backoff_policy.cc
@@ -1,0 +1,43 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <random>
+
+#include "backoff_policy.h"
+
+namespace google {
+namespace gax {
+
+std::chrono::microseconds ExponentialBackoffPolicy::OnCompletion() {
+  if(!generator_) {
+    generator_ = std::unique_ptr<std::mt19937_64>(new std::mt19937_64(std::random_device()()));
+  }
+
+  std::uniform_int_distribution<std::chrono::microseconds::rep> dist(current_delay_range_.count() / 2,
+                                                                     current_delay_range_.count());
+  auto delay = std::chrono::microseconds(dist(*generator_));
+
+  current_delay_range_ = std::min(maximum_delay_, current_delay_range_*2);
+  return delay;
+}
+
+std::unique_ptr<BackoffPolicy> ExponentialBackoffPolicy::clone() const {
+  return std::unique_ptr<BackoffPolicy>(new ExponentialBackoffPolicy(*this));
+}
+
+}  // namespace gax
+}  // namespace google

--- a/gax/backoff_policy.h
+++ b/gax/backoff_policy.h
@@ -19,11 +19,7 @@
 #include <memory>
 #include <random>
 
-// Note: gtest-1.8.1 doesn't have a separate target for gtest_prod.
-//       Rather than add an overlarge dependency on @gtest//:gtest,
-//       just define the necessary macro ourselves.
-#define FRIEND_TEST(test_case_name, test_name)\
-friend class test_case_name##_##test_name##_Test
+#include "internal/gtest_prod.h"
 
 namespace google {
 namespace gax {

--- a/gax/backoff_policy.h
+++ b/gax/backoff_policy.h
@@ -1,0 +1,164 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_GAX_BACKOFF_POLICY_H_
+#define GOOGLE_GAX_BACKOFF_POLICY_H_
+
+#include <chrono>
+#include <memory>
+#include <random>
+
+// Note: gtest-1.8.1 doesn't have a separate target for gtest_prod.
+//       Rather than add an overlarge dependency on @gtest//:gtest,
+//       just define the necessary macro ourselves.
+#define FRIEND_TEST(test_case_name, test_name)\
+friend class test_case_name##_##test_name##_Test
+
+namespace google {
+namespace gax {
+
+/**
+ * Define the interface for backoff policies.
+ *
+ * The client libraries need to hide partial and temporary failures from the
+ * application. Exponential backoff is generally considered a best practice when
+ * retrying operations. However, the details of how exponetial backoff is
+ * implemented and tuned varies widely. We need to give the users enough
+ * flexibility, and also provide sensible default implementations.
+ *
+ * The client library receives an object of this type and clones a new instance
+ * for each operation. That is, the application provides the library with a
+ * [Prototype](https://en.wikipedia.org/wiki/Prototype_pattern) of the policy
+ * that will be applied to each operation.
+ *
+ * [Truncated Exponential
+ * Backoff](https://cloud.google.com/storage/docs/exponential-backoff) in the
+ * Google Cloud Storage documentation.
+ *
+ */
+class BackoffPolicy {
+ public:
+  virtual ~BackoffPolicy() = default;
+
+  /**
+   * Handle an operation completion.
+   *
+   * This function is called when an operation has failed and needs to be retried.
+   * The decision to retry or not is handled by other policies.
+   *
+   * @return the delay to wait before the next retry attempt.
+   */
+  virtual std::chrono::microseconds OnCompletion() = 0;
+
+  /**
+   * Return a new copy of this object.
+   */
+  virtual std::unique_ptr<BackoffPolicy> clone() const = 0;
+};
+
+/**
+ * Implements a truncated exponential backoff with randomization policy.
+ *
+ * This policy implements the truncated exponential backoff policy for
+ * retrying operations. After a request fails, and subject to a separate
+ * retry policy, the client library will wait for an initial delay before
+ * trying again. If the second attempt fails the delay time is increased by a factor
+ * of 2. The delay time growth stops at a maximum delay wait time.
+ * The policy also randomizes the delay each time, to avoid
+ * [thundering herd
+ * problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+ *
+ * Note: The random number generator used when calculating backoff time in
+ *       OnCompletion is lazily created. Furthermore, GeneratorFactory::Generator
+ *       may touch mutable shared state.
+ *       As a result, OnCompletion is NOT thread-safe.
+ *       All other methods, including clone, are thread-safe.
+ *       ExponentialBackoffPolicy is therefore thread-compatible.
+ */
+class ExponentialBackoffPolicy : BackoffPolicy {
+ public:
+  /**
+   * Constructor for an exponential backoff policy.
+   *
+   * Define the initial delay and maximum delay for an instance
+   * of the policy. While the constructor accepts `std::chrono::duration`
+   * objects at any resolution, the data is kept internally in microseconds.
+   * Sub-microsecond delays seem unnecessarily precise for this application.
+   *
+   * @code
+   * using namespace std::chrono_literals; // C++14
+   * auto r1 = ExponentialBackoffPolicy(10ms, 500ms);
+   * @endcode
+   *
+   * @param initial_delay how long to wait after the first (unsuccessful)
+   *     operation.
+   * @param maximum_delay the maximum value for the delay between operations.
+   *
+   * @tparam duration1_t a placeholder to match the Rep tparam for @p initial_delay's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the underlying arithmetic type
+   *     used to store the number of ticks), for our purposes it is simply a
+   *     formal parameter.
+   * @tparam d1 a placeholder to match the Period tparam for
+   *     @p initial_delay's type, the semantics of this template parameter are
+   *     documented in `std::chrono::duration<>` (in brief, the length of the
+   *     tick in seconds, expressed as a `std::ratio<>`), for our purposes it
+   *     is simply a formal parameter.
+   * @tparam duration2_t similar formal parameter for the type of @p maximum_delay.
+   * @tparam d2 similar formal parameter for the type of @p maximum_delay.
+   *
+   * @see
+   * [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
+   *     for more details.
+   */
+  template<typename duration1_t, typename duration2_t>
+  ExponentialBackoffPolicy(duration1_t d1, duration2_t d2) :
+      initial_delay_(std::chrono::duration_cast<std::chrono::microseconds>(d1)),
+      current_delay_range_(initial_delay_),
+      maximum_delay_(std::chrono::duration_cast<std::chrono::microseconds>(d2)) {}
+
+  ExponentialBackoffPolicy(ExponentialBackoffPolicy const& rhs) noexcept
+      : ExponentialBackoffPolicy(rhs.initial_delay_, rhs.maximum_delay_) {}
+
+  ExponentialBackoffPolicy(ExponentialBackoffPolicy&& rhs) noexcept
+      : initial_delay_(std::move(rhs.initial_delay_)),
+        current_delay_range_(initial_delay_),
+        maximum_delay_(std::move(rhs.maximum_delay_)),
+        generator_(std::move(rhs.generator_)) {}
+
+  std::chrono::microseconds OnCompletion() override;
+
+  std::unique_ptr<BackoffPolicy> clone() const override;
+
+ private:
+  FRIEND_TEST(ExponentialBackoffPolicy, Basic);
+  FRIEND_TEST(ExponentialBackoffPolicy, CopyConstruct);
+  FRIEND_TEST(ExponentialBackoffPolicy, MoveConstruct);
+  FRIEND_TEST(ExponentialBackoffPolicy, Clone);
+  FRIEND_TEST(ExponentialBackoffPolicy, LazyGenerator);
+
+  std::chrono::microseconds const initial_delay_;
+  std::chrono::microseconds current_delay_range_;
+  std::chrono::microseconds const maximum_delay_;
+
+  // Store via pointer and do not initialize until OnCompletion is called.
+  // The 19937 refers to bits of state: as a result, generator_ is very large,
+  // is expensive to create, and in any case most rpcs succeed on the first call.
+  std::unique_ptr<std::mt19937_64> generator_;
+};
+
+}  // namespace gax
+}  // namespace google
+
+#endif  // GOOGLE_GAX_BACKOFF_POLICY_H_

--- a/gax/backoff_policy_unittest.cc
+++ b/gax/backoff_policy_unittest.cc
@@ -1,0 +1,104 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <random>
+
+#include "googletest/include/gtest/gtest.h"
+
+#include "backoff_policy.h"
+
+namespace google {
+namespace gax {
+
+TEST(ExponentialBackoffPolicy, Basic) {
+  ExponentialBackoffPolicy tested(std::chrono::milliseconds(1),
+                                  std::chrono::milliseconds(32));
+
+  for(int i = 0; i < 5; ++i){
+    auto base_delay = tested.current_delay_range_;
+    EXPECT_EQ(base_delay, std::chrono::milliseconds(1<<i));
+    auto delay = tested.OnCompletion();
+    EXPECT_GE(delay, base_delay/2.0);
+    EXPECT_LE(delay, base_delay);
+  }
+
+  EXPECT_EQ(tested.current_delay_range_, tested.maximum_delay_);
+  // current_delay_range_ saturates to max delay.
+  tested.OnCompletion();
+  EXPECT_EQ(tested.current_delay_range_, tested.maximum_delay_);
+}
+
+TEST(ExponentialBackoffPolicy, CopyConstruct) {
+  ExponentialBackoffPolicy tested(std::chrono::milliseconds(10),
+                                  std::chrono::milliseconds(320));
+  tested.OnCompletion();
+  ExponentialBackoffPolicy copy(tested);  // Copy starts with fresh backoff delays
+
+  EXPECT_EQ(copy.current_delay_range_, std::chrono::milliseconds(10));
+  EXPECT_EQ(copy.maximum_delay_, std::chrono::milliseconds(320));
+}
+
+TEST(ExponentialBackoffPolicy, MoveConstruct) {
+  ExponentialBackoffPolicy tested(std::chrono::milliseconds(10),
+                                  std::chrono::milliseconds(320));
+  tested.OnCompletion();
+  ExponentialBackoffPolicy moved(std::move(tested));  // Starts with fresh backoff delays
+
+  EXPECT_EQ(moved.current_delay_range_, std::chrono::milliseconds(10));
+  EXPECT_EQ(moved.maximum_delay_, std::chrono::milliseconds(320));
+}
+
+TEST(ExponentialBackoffPolicy, Clone) {
+  ExponentialBackoffPolicy tested(std::chrono::milliseconds(10),
+                                  std::chrono::milliseconds(320));
+  tested.OnCompletion();
+  std::unique_ptr<BackoffPolicy> clone = tested.clone();
+
+  // We need to check that the clone method has the right signature, but we also need
+  // to check that the clone attributes have the right initial values.
+  auto cast_clone = std::unique_ptr<ExponentialBackoffPolicy>(
+      static_cast<ExponentialBackoffPolicy*>(clone.release()));
+
+  EXPECT_EQ(cast_clone->current_delay_range_, std::chrono::milliseconds(10));
+  EXPECT_EQ(cast_clone->maximum_delay_, std::chrono::milliseconds(320));
+}
+
+TEST(ExponentialBackoffPolicy, LazyGenerator) {
+  ExponentialBackoffPolicy tested(std::chrono::milliseconds(10),
+                                  std::chrono::milliseconds(320));
+  EXPECT_EQ(tested.generator_, nullptr);
+  tested.OnCompletion();
+  EXPECT_NE(tested.generator_, nullptr);
+
+  // Copies and clones use their own lazily constructed generators
+  ExponentialBackoffPolicy copy(tested);
+  EXPECT_EQ(copy.generator_, nullptr);
+  copy.OnCompletion();
+  EXPECT_NE(copy.generator_, nullptr);
+
+  auto clone = std::unique_ptr<ExponentialBackoffPolicy>(
+      static_cast<ExponentialBackoffPolicy*>(copy.clone().release()));
+  EXPECT_EQ(clone->generator_, nullptr);
+  clone->OnCompletion();
+  EXPECT_NE(clone->generator_, nullptr);
+
+  // Moves reuse the existing generator
+  ExponentialBackoffPolicy move(std::move(tested));
+  EXPECT_NE(move.generator_, nullptr);
+}
+
+}  // namespace gax
+}  // namespace google

--- a/gax/internal/gtest_prod.h
+++ b/gax/internal/gtest_prod.h
@@ -1,0 +1,24 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_GAX_INTERNAL_GTEST_PROD_H_
+#define GOOGLE_GAX_INTERNAL_GTEST_PROD_H_
+
+// Note: gtest-1.8.1 doesn't have a separate target for gtest_prod.
+//       Rather than add an overlarge dependency on @gtest//:gtest,
+//       just define the necessary macro ourselves.
+#define FRIEND_TEST(test_case_name, test_name)\
+friend class test_case_name##_##test_name##_Test
+
+#endif  // GOOGLE_GAX_INTERNAL_GTEST_PROD_H_


### PR DESCRIPTION
When an operation fails and needs to be retried, a BackoffPolicy object
determines how long to wait before attempting the retry.

The single concrete implementation is a saturating binary exponential
backoff with randomized delay that is (intended to be) unique across
clone/copy construction.
Actual unique generation of the per-policy RNG is punted to a functor
template parameter.