### PR TITLE
Moved gtest_prod from hdrs to srcs

### DIFF
--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -20,11 +20,11 @@ cc_library(
     name = "gax",
     srcs = [
         "backoff_policy.cc",
+        "internal/gtest_prod.h",
         "status.cc",
     ],
     hdrs = [
         "backoff_policy.h",
-        "internal/gtest_prod.h",
         "retry_policy.h",
         "status.h",
     ],


### PR DESCRIPTION
Because we don't want to expose this outside our repo, we should place it in srcs rather than headers (see https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library)