### PR TITLE
Add printer class to wrap protobuf IO classes

### DIFF
--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -21,6 +21,7 @@ cc_library(
     srcs = [
         "gapic_generator.cc",
         "internal/gapic_utils.h",
+        "internal/printer.h",
     ],
     hdrs = [
         "gapic_generator.h",

--- a/generator/internal/printer.h
+++ b/generator/internal/printer.h
@@ -1,0 +1,51 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GOOGLE_API_CODEGEN_INTERNAL_PRINTER_H_
+#define GOOGLE_API_CODEGEN_INTERNAL_PRINTER_H_
+
+#include <string>
+#include "src/google/protobuf/compiler/code_generator.h"
+#include "src/google/protobuf/io/printer.h"
+
+namespace pb = google::protobuf;
+
+namespace google {
+namespace api {
+namespace codegen {
+namespace internal {
+
+class Printer {
+ public:
+  Printer(pb::compiler::GeneratorContext* generator_context,
+          std::string const& file_name)
+    : output_(generator_context->Open(file_name)),
+      printer_(output_.get(), '$', NULL) {}
+
+  pb::io::Printer* operator->() & { return &printer_; }
+  pb::io::Printer const* operator->() const& { return &printer_; }
+
+  Printer(Printer const&) = delete;
+  Printer& operator=(Printer const&) = delete;
+
+ private:
+  std::unique_ptr<pb::io::ZeroCopyOutputStream> output_;
+  pb::io::Printer printer_;
+};
+
+} // internal
+} // codegen
+} // api
+} // google
+
+#endif // GOOGLE_API_CODEGEN_INTERNAL_PRINTER_H_

--- a/generator/internal/printer.h
+++ b/generator/internal/printer.h
@@ -25,22 +25,27 @@ namespace api {
 namespace codegen {
 namespace internal {
 
+/**
+ * Wrapper around a google::protobuf::io::ZeroCopyOutputStream and a
+ * google::protobuf::io::Printer object so that they can be used for
+ * code generation. 
+ */
 class Printer {
  public:
   Printer(pb::compiler::GeneratorContext* generator_context,
           std::string const& file_name)
     : output_(generator_context->Open(file_name)),
-      printer_(output_.get(), '$', NULL) {}
+      printer_(new pb::io::Printer(output_.get(), '$', NULL)) {}
 
-  pb::io::Printer* operator->() & { return &printer_; }
-  pb::io::Printer const* operator->() const& { return &printer_; }
+  pb::io::Printer* operator->() & { return printer_.get(); }
+  pb::io::Printer const* operator->() const& { return printer_.get(); }
 
   Printer(Printer const&) = delete;
   Printer& operator=(Printer const&) = delete;
 
  private:
   std::unique_ptr<pb::io::ZeroCopyOutputStream> output_;
-  pb::io::Printer printer_;
+  std::unique_ptr<pb::io::Printer> printer_;
 };
 
 } // internal

--- a/generator/internal/printer.h
+++ b/generator/internal/printer.h
@@ -35,17 +35,17 @@ class Printer {
   Printer(pb::compiler::GeneratorContext* generator_context,
           std::string const& file_name)
     : output_(generator_context->Open(file_name)),
-      printer_(new pb::io::Printer(output_.get(), '$', NULL)) {}
+      printer_(output_.get(), '$', NULL) {}
 
-  pb::io::Printer* operator->() & { return printer_.get(); }
-  pb::io::Printer const* operator->() const& { return printer_.get(); }
+  pb::io::Printer* operator->() & { return &printer_; }
+  pb::io::Printer const* operator->() const& { return &printer_; }
 
   Printer(Printer const&) = delete;
   Printer& operator=(Printer const&) = delete;
 
  private:
   std::unique_ptr<pb::io::ZeroCopyOutputStream> output_;
-  std::unique_ptr<pb::io::Printer> printer_;
+  pb::io::Printer printer_;
 };
 
 } // internal


### PR DESCRIPTION
Wrap construction of a protobuf ZeroCopyOutputStream and Printer into a single class that can manage their lifetime and construct the printer with the correct delimiter.