### PR TITLE
Add standalone mode for gapic-generator

### DIFF
--- a/gax/backoff_policy_unittest.cc
+++ b/gax/backoff_policy_unittest.cc
@@ -16,7 +16,7 @@
 #include <memory>
 #include <random>
 
-#include "googletest/include/gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "backoff_policy.h"
 

--- a/gax/repositories.bzl
+++ b/gax/repositories.bzl
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "com_google_gapic_generator_cpp")
+def com_google_gapic_generator_cpp_gax_repositories():
+    _maybe(
+        http_archive,
+        name = "com_github_grpc_grpc",
+        strip_prefix = "grpc-1.18.0",
+        urls = ["https://github.com/grpc/grpc/archive/v1.18.0.tar.gz"]
+    )
 
-load(
-    "//:repositories.bzl",
-    "com_google_gapic_generator_cpp_repositories",
-)
 
-com_google_gapic_generator_cpp_repositories()
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)

--- a/gax/retry_policy_unittest.cc
+++ b/gax/retry_policy_unittest.cc
@@ -15,9 +15,9 @@
 #include <chrono>
 #include <memory>
 
-#include <gtest/gtest.h>
 #include "retry_policy.h"
 #include "status.h"
+#include <gtest/gtest.h>
 
 namespace {
 using namespace ::google;

--- a/gax/retry_policy_unittest.cc
+++ b/gax/retry_policy_unittest.cc
@@ -15,7 +15,7 @@
 #include <chrono>
 #include <memory>
 
-#include "googletest/include/gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "retry_policy.h"
 #include "status.h"
 

--- a/gax/status_or_unittest.cc
+++ b/gax/status_or_unittest.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "status_or.h"
-#include <gtest/gtest.h>
 #include "status.h"
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <string>

--- a/gax/status_or_unittest.cc
+++ b/gax/status_or_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "status_or.h"
-#include "googletest/include/gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "status.h"
 
 #include <memory>

--- a/gax/status_unittest.cc
+++ b/gax/status_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "status.h"
-#include "googletest/include/gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <sstream>
 #include <string>

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -12,30 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])  # Apache 2.0
 
 cc_library(
-    name = "cpp_gapic_generator",
+    name = "gapic_generator",
     srcs = [
         "gapic_generator.cc",
         "internal/client_cc_generator.cc",
         "internal/client_cc_generator.h",
-        "internal/stub_cc_generator.cc",
-        "internal/stub_cc_generator.h",
         "internal/client_header_generator.cc",
         "internal/client_header_generator.h",
-        "internal/stub_header_generator.cc",
-        "internal/stub_header_generator.h",
         "internal/data_model.h",
         "internal/gapic_utils.cc",
         "internal/gapic_utils.h",
         "internal/printer.h",
+        "internal/stub_cc_generator.cc",
+        "internal/stub_cc_generator.h",
+        "internal/stub_header_generator.cc",
+        "internal/stub_header_generator.h",
+        "standalone.cc",
+        "standalone.h",
     ],
     hdrs = [
         "gapic_generator.h",
     ],
+    includes = ["."],
     deps = [
         "@absl//absl/base",
         "@absl//absl/strings",
@@ -44,41 +45,43 @@ cc_library(
     ],
 )
 
+# The protoc plugin/standalone binary. The name (proto-gen-cpp_gapic) is ugly
+# but it is a naming requirement for protoc plugins. To use --cpp_gapic_out
+# command line argument without need to provide additional --plugin argument,
+# the binary must be named proto-gen-cpp_gapic and placed in a PATH.
 cc_binary(
-    name = "cpp_gapic_generator_plugin",
-    srcs = ["plugin.cc"],
-    deps = [
-        ":cpp_gapic_generator",
-    ],
+    name = "protoc-gen-cpp_gapic",
+    srcs = ["main.cc"],
+    includes = ["."],
+    deps = [":gapic_generator"],
 )
 
 cc_test(
     name = "gapic_generator_unittest",
     size = "small",
     srcs = ["gapic_generator_unittest.cc"],
-    data = glob(
-        ["testdata/**"],
-    ) + [
+    data = [
+        "//generator/testdata:library_proto",
+        "//generator/testdata:library_service_baseline",
         "@api_common_protos//google/api:client_proto",
+        "@com_google_protobuf//:descriptor_proto",
     ],
     deps = [
-        "//generator:cpp_gapic_generator",
+        ":gapic_generator",
         "@gtest//:gtest_main",
     ],
 )
-
-generator_unit_tests = [
-    "internal/gapic_utils_unittest.cc",
-]
 
 [cc_test(
     name = "generator_" + test.replace("/", "_").replace(".cc", ""),
     size = "small",
     srcs = [test],
     deps = [
-        "//generator:cpp_gapic_generator",
+        "//generator:gapic_generator",
         "@absl//absl/base",
         "@absl//absl/strings",
         "@gtest//:gtest_main",
     ],
-) for test in generator_unit_tests]
+) for test in [
+    "internal/gapic_utils_unittest.cc",
+]]

--- a/generator/gapic_generator.h
+++ b/generator/gapic_generator.h
@@ -14,12 +14,10 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_GAPIC_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_GAPIC_GENERATOR_H_
 
-#include <memory>
-#include <sstream>
 #include <string>
 
-#include "src/google/protobuf/compiler/code_generator.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/compiler/code_generator.h>
+#include <google/protobuf/descriptor.h>
 
 namespace google {
 namespace api {

--- a/generator/gapic_generator_unittest.cc
+++ b/generator/gapic_generator_unittest.cc
@@ -25,7 +25,6 @@
 #include <gapic_generator.h>
 #include <standalone.h>
 
-
 namespace google {
 namespace api {
 namespace codegen {
@@ -48,13 +47,13 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
   const std::string data_dir("./generator/testdata/");
 
   std::vector<std::string> descriptors = {
-      input_dir
-          + "com_google_gapic_generator_cpp/generator/testdata/library_proto-descriptor-set.proto.bin",
-      input_dir
-          + "api_common_protos/google/api/client_proto-descriptor-set.proto.bin",
-      input_dir
-          + "com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"
-  };
+      input_dir +
+          "com_google_gapic_generator_cpp/generator/testdata/"
+          "library_proto-descriptor-set.proto.bin",
+      input_dir +
+          "api_common_protos/google/api/client_proto-descriptor-set.proto.bin",
+      input_dir +
+          "com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"};
   std::string package = "google.example.library.v1";
 
   GapicGenerator generator;

--- a/generator/gapic_generator_unittest.cc
+++ b/generator/gapic_generator_unittest.cc
@@ -17,7 +17,6 @@
 #include <string>
 #include <vector>
 
-#include <dirent.h>
 #include <iostream>
 
 #include <gtest/gtest.h>
@@ -39,9 +38,6 @@ inline std::string LoadContent(const std::string& f) {
 }
 
 TEST(GapicGeneratorBaselineTest, StandaloneTest) {
-  char cwd[PATH_MAX];
-  getcwd(cwd, sizeof(cwd));
-
   const std::string input_dir("../");
   const std::string output_dir("./");
   const std::string data_dir("./generator/testdata/");

--- a/generator/gapic_generator_unittest.cc
+++ b/generator/gapic_generator_unittest.cc
@@ -20,63 +20,47 @@
 #include <dirent.h>
 #include <iostream>
 
-#include "absl/strings/str_cat.h"
+#include <gtest/gtest.h>
 
-#include "src/google/protobuf/compiler/command_line_interface.h"
-#include "src/google/protobuf/io/printer.h"
-#include "src/google/protobuf/io/zero_copy_stream.h"
+#include <gapic_generator.h>
+#include <standalone.h>
 
-#include "googletest/include/gtest/gtest.h"
 
-#include "generator/gapic_generator.h"
+namespace google {
+namespace api {
+namespace codegen {
 
-namespace {
 namespace pb = google::protobuf;
-namespace codegen = google::api::codegen;
 
-inline std::string LoadContent(std::string f) {
+inline std::string LoadContent(const std::string& f) {
   std::ifstream ifs(f);
   EXPECT_TRUE(ifs.good()) << "Could not open " << f;
   return std::string((std::istreambuf_iterator<char>(ifs)),
                      (std::istreambuf_iterator<char>()));
 }
 
-TEST(CppGapicPluginTest, GapicPluginTest) {
-  std::string workspace_dir = ".";
-  std::string external_dir = workspace_dir + "/..";
-  std::string test_dir = workspace_dir + "/generator";
-  std::string test_data_dir = test_dir + "/testdata";
-  std::string gapic_out_dir = workspace_dir;
+TEST(GapicGeneratorBaselineTest, StandaloneTest) {
+  char cwd[PATH_MAX];
+  getcwd(cwd, sizeof(cwd));
 
-  DIR* dirp = opendir(".");
-  struct dirent* dp;
-  while ((dp = readdir(dirp)) != NULL) {
-    std::cout << dp->d_name << std::endl;
-  }
+  const std::string input_dir("../");
+  const std::string output_dir("./hoho.zip");
+  const std::string data_dir("./generator/testdata/");
 
-  pb::compiler::CommandLineInterface cli;
-  cli.SetInputsAreProtoPathRelative(true);
+  std::vector<std::string> descriptors = {
+      input_dir
+          + "com_google_gapic_generator_cpp/generator/testdata/library_proto-descriptor-set.proto.bin",
+      input_dir
+          + "api_common_protos/google/api/client_proto-descriptor-set.proto.bin",
+      input_dir
+          + "com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"
+  };
+  std::string package = "google.example.library.v1";
 
-  codegen::GapicGenerator generator;
-  cli.RegisterGenerator("--cpp_gapic_out", &generator, "");
+  GapicGenerator generator;
 
-  std::string workspace_proto_path = "-I" + workspace_dir;
-  std::string annotations_proto_path =
-      "-I" + external_dir + "/api_common_protos";
-  std::string well_known_types_proto_path =
-      "-I" + external_dir + "/com_google_protobuf";
-  std::string cpp_out = "--cpp_gapic_out=" + gapic_out_dir;
-  std::string library_proto = test_data_dir + "/library.proto";
-
-  char const* argv[] = {"protoc",
-                        workspace_proto_path.c_str(),
-                        annotations_proto_path.c_str(),
-                        well_known_types_proto_path.c_str(),
-                        cpp_out.c_str(),
-                        library_proto.c_str()};
-
-  EXPECT_EQ(0, cli.Run(sizeof(argv) / sizeof(argv[0]), argv))
-      << "cli.Run failed";
+  int res = StandaloneMain(descriptors, package, output_dir, &generator);
+  EXPECT_EQ(0, res) << "StandaloneMain failed";
 
   std::vector<std::string> files_to_check{
       "google/example/library/v1/library_service.gapic.h",
@@ -85,16 +69,17 @@ TEST(CppGapicPluginTest, GapicPluginTest) {
       "google/example/library/v1/library_service_stub.gapic.cc",
   };
 
-  for (std::string const& f : files_to_check) {
-    std::string actual_file = absl::StrCat(gapic_out_dir, "/", f);
-    std::string expected_file =
-        absl::StrCat(test_data_dir, "/", f, ".baseline");
+  for (const std::string& file : files_to_check) {
+    const std::string expected_file(data_dir + file + ".baseline");
+    const std::string actual_file(output_dir + file);
 
-    std::string actual_file_content = LoadContent(actual_file);
-    std::string expected_file_content = LoadContent(expected_file);
+    const std::string& expected_file_content = LoadContent(expected_file);
+    const std::string& actual_file_content = LoadContent(actual_file);
 
     EXPECT_EQ(expected_file_content, actual_file_content);
   }
 }
 
-}  // namespace
+}  // namespace codegen
+}  // namespace api
+}  // namespace google

--- a/generator/gapic_generator_unittest.cc
+++ b/generator/gapic_generator_unittest.cc
@@ -30,7 +30,7 @@ namespace codegen {
 
 namespace pb = google::protobuf;
 
-inline std::string LoadContent(const std::string& f) {
+inline std::string LoadContent(std::string const& f) {
   std::ifstream ifs(f);
   EXPECT_TRUE(ifs.good()) << "Could not open " << f;
   return std::string((std::istreambuf_iterator<char>(ifs)),
@@ -38,9 +38,9 @@ inline std::string LoadContent(const std::string& f) {
 }
 
 TEST(GapicGeneratorBaselineTest, StandaloneTest) {
-  const std::string input_dir("../");
-  const std::string output_dir("./");
-  const std::string data_dir("./generator/testdata/");
+  std::string const input_dir("../");
+  std::string const output_dir("./");
+  std::string const data_dir("./generator/testdata/");
 
   std::vector<std::string> descriptors = {
       input_dir +
@@ -64,12 +64,12 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
       "google/example/library/v1/library_service_stub.gapic.cc",
   };
 
-  for (const std::string& file : files_to_check) {
-    const std::string expected_file(data_dir + file + ".baseline");
-    const std::string actual_file(output_dir + file);
+  for (auto const& file : files_to_check) {
+    std::string const expected_file(data_dir + file + ".baseline");
+    std::string const actual_file(output_dir + file);
 
-    const std::string& expected_file_content = LoadContent(expected_file);
-    const std::string& actual_file_content = LoadContent(actual_file);
+    std::string const& expected_file_content = LoadContent(expected_file);
+    std::string const& actual_file_content = LoadContent(actual_file);
 
     EXPECT_EQ(expected_file_content, actual_file_content);
   }

--- a/generator/gapic_generator_unittest.cc
+++ b/generator/gapic_generator_unittest.cc
@@ -44,7 +44,7 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
   getcwd(cwd, sizeof(cwd));
 
   const std::string input_dir("../");
-  const std::string output_dir("./hoho.zip");
+  const std::string output_dir("./");
   const std::string data_dir("./generator/testdata/");
 
   std::vector<std::string> descriptors = {

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -18,9 +18,9 @@
 
 #include "gapic_utils.h"
 #include "printer.h"
-#include <google/protobuf/descriptor.h>
 #include "generator/internal/client_cc_generator.h"
 #include "generator/internal/data_model.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -18,7 +18,7 @@
 
 #include "gapic_utils.h"
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 #include "generator/internal/client_cc_generator.h"
 #include "generator/internal/data_model.h"
 

--- a/generator/internal/client_cc_generator.h
+++ b/generator/internal/client_cc_generator.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -18,9 +18,9 @@
 
 #include "gapic_utils.h"
 #include "printer.h"
-#include <google/protobuf/descriptor.h>
 #include "generator/internal/client_header_generator.h"
 #include "generator/internal/data_model.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -18,7 +18,7 @@
 
 #include "gapic_utils.h"
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 #include "generator/internal/client_header_generator.h"
 #include "generator/internal/data_model.h"
 

--- a/generator/internal/client_header_generator.h
+++ b/generator/internal/client_header_generator.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/data_model.h
+++ b/generator/internal/data_model.h
@@ -24,9 +24,9 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "google/api/client.pb.h"
-#include "src/google/protobuf/compiler/code_generator.h"
-#include "src/google/protobuf/descriptor.h"
-#include "src/google/protobuf/descriptor.pb.h"
+#include <google/protobuf/compiler/code_generator.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
 
 #include "gapic_utils.h"
 #include "printer.h"

--- a/generator/internal/gapic_utils.h
+++ b/generator/internal/gapic_utils.h
@@ -23,7 +23,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 
 namespace google {
 namespace api {

--- a/generator/internal/gapic_utils_unittest.cc
+++ b/generator/internal/gapic_utils_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "generator/internal/gapic_utils.h"
-#include "googletest/include/gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <string>
 #include <utility>
 #include <vector>

--- a/generator/internal/printer.h
+++ b/generator/internal/printer.h
@@ -14,9 +14,9 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_PRINTER_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_PRINTER_H_
 
-#include "src/google/protobuf/compiler/code_generator.h"
-#include "src/google/protobuf/io/printer.h"
-#include "src/google/protobuf/io/zero_copy_stream.h"
+#include <google/protobuf/compiler/code_generator.h>
+#include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/zero_copy_stream.h>
 #include <string>
 
 namespace pb = google::protobuf;

--- a/generator/internal/stub_cc_generator.cc
+++ b/generator/internal/stub_cc_generator.cc
@@ -15,8 +15,8 @@
 #include "stub_cc_generator.h"
 #include "gapic_utils.h"
 #include "printer.h"
-#include <google/protobuf/descriptor.h>
 #include "generator/internal/data_model.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/stub_cc_generator.cc
+++ b/generator/internal/stub_cc_generator.cc
@@ -15,7 +15,7 @@
 #include "stub_cc_generator.h"
 #include "gapic_utils.h"
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 #include "generator/internal/data_model.h"
 
 namespace pb = google::protobuf;

--- a/generator/internal/stub_cc_generator.h
+++ b/generator/internal/stub_cc_generator.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -17,7 +17,7 @@
 
 #include "data_model.h"
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 #include "stub_header_generator.h"
 
 namespace pb = google::protobuf;

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -17,8 +17,8 @@
 
 #include "data_model.h"
 #include "printer.h"
-#include <google/protobuf/descriptor.h>
 #include "stub_header_generator.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/stub_header_generator.h
+++ b/generator/internal/stub_header_generator.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "printer.h"
-#include "src/google/protobuf/descriptor.h"
+#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/main.cc
+++ b/generator/main.cc
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/google/protobuf/compiler/plugin.h"
-#include "gapic_generator.h"
+//#include <fstream>
+
+#include <standalone.h>
+#include <google/protobuf/compiler/plugin.h>
+#include <gapic_generator.h>
 
 /**
- * Entry point for C++ GAPIC generator protoc plugin.
+ * Entry point for C++ GAPIC generator.
+ *
+ * If at least one command line argument is provided, the standalone mode is
+ * assumed. Otherwise thegenerator runs as a plugin (it expects input to be
+ * received via stdin and outputs to stdout).
  */
 int main(int argc, char** argv) {
   google::api::codegen::GapicGenerator generator;
+  if (argc > 1) {
+    return google::api::codegen::StandaloneMain(argc, argv, &generator);
+  }
+  // PluginMain immediately fails if argc > 1
   return google::protobuf::compiler::PluginMain(argc, argv, &generator);
 }

--- a/generator/main.cc
+++ b/generator/main.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//#include <fstream>
-
 #include <google/protobuf/compiler/plugin.h>
 #include <gapic_generator.h>
 #include <standalone.h>
@@ -22,7 +20,7 @@
  * Entry point for C++ GAPIC generator.
  *
  * If at least one command line argument is provided, the standalone mode is
- * assumed. Otherwise thegenerator runs as a plugin (it expects input to be
+ * assumed. Otherwise the generator runs as a plugin (it expects input to be
  * received via stdin and outputs to stdout).
  */
 int main(int argc, char** argv) {

--- a/generator/main.cc
+++ b/generator/main.cc
@@ -14,9 +14,9 @@
 
 //#include <fstream>
 
-#include <standalone.h>
 #include <google/protobuf/compiler/plugin.h>
 #include <gapic_generator.h>
+#include <standalone.h>
 
 /**
  * Entry point for C++ GAPIC generator.

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -1,5 +1,5 @@
-#include <standalone.h>
 #include <fstream>
+#include <standalone.h>
 
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/stubs/io_win32.h>
@@ -19,12 +19,10 @@ namespace pb = google::protobuf;
 //
 // This function extracts the relevant file names (those, which match the
 // package) from the set of descriptors.
-bool ExtractFileNames(
-    const std::vector<std::string>& desc_sets,
-    const std::vector<std::string>& packages,
-    std::vector<std::string>& filenames,
-    std::string* error_msg) {
-
+bool ExtractFileNames(const std::vector<std::string>& desc_sets,
+                      const std::vector<std::string>& packages,
+                      std::vector<std::string>& filenames,
+                      std::string* error_msg) {
   for (const std::string& desc_set : desc_sets) {
     if (desc_set.empty()) {
       continue;
@@ -64,8 +62,7 @@ void ParseDelimitedArg(const std::string& arg,
   size_t p0 = 0;
   for (const char* d = delimiters; *d != '\0' && tokens.empty(); d++) {
     p0 = 0;
-    for (size_t p = arg.find(*d, 0);
-         p != std::string::npos;
+    for (size_t p = arg.find(*d, 0); p != std::string::npos;
          p0 = p + 1, p = arg.find(*d, p0)) {
       tokens.emplace_back(arg.substr(p0, p - p0));
     }
@@ -87,8 +84,7 @@ void ParseDelimitedArg(const std::string& arg,
 //   this is especially useful for folder operations, since standard library
 //   below C++17 does not have folder I/O abstraction whatsoever.
 //
-bool ConvertCommandLineArgs(int argc,
-                            const char* const argv[],
+bool ConvertCommandLineArgs(int argc, const char* const argv[],
                             std::vector<std::string>& args,
                             std::string* error_msg) {
   // GAPIC Generator Standalone arguments
@@ -129,16 +125,14 @@ bool ConvertCommandLineArgs(int argc,
     if (!ExtractFileNames(desc_set_in, packages, file_names, error_msg)) {
       return false;
     }
-    args.insert(args.end(),
-                std::make_move_iterator(file_names.begin()),
+    args.insert(args.end(), std::make_move_iterator(file_names.begin()),
                 std::make_move_iterator(file_names.end()));
   }
 
   return true;
 }
 
-int StandaloneMain(int argc,
-                   const char* const argv[],
+int StandaloneMain(int argc, const char* const argv[],
                    google::protobuf::compiler::CodeGenerator* generator) {
   std::string error_msg;
   std::vector<std::string> args;
@@ -153,12 +147,11 @@ int StandaloneMain(int argc,
     c_args.push_back(arg.c_str());
   }
 
-  return cli.Run((int) args.size(), c_args.data());
+  return cli.Run((int)args.size(), c_args.data());
 }
 
 int StandaloneMain(const std::vector<std::string>& descriptors,
-                   const std::string& package,
-                   const std::string& output,
+                   const std::string& package, const std::string& output,
                    google::protobuf::compiler::CodeGenerator* generator) {
   std::string desc_set_in_arg("--descriptor=");
   for (const std::string& desc_set : descriptors) {
@@ -167,12 +160,10 @@ int StandaloneMain(const std::vector<std::string>& descriptors,
   std::string package_arg("--package=" + package);
   std::string output_arg("--output=" + output);
 
-  std::vector<const char*> c_args = {"<ignored>",
-                                     desc_set_in_arg.c_str(),
-                                     package_arg.c_str(),
-                                     output_arg.c_str()};
+  std::vector<const char*> c_args = {"<ignored>", desc_set_in_arg.c_str(),
+                                     package_arg.c_str(), output_arg.c_str()};
 
-  return StandaloneMain((int) c_args.size(), c_args.data(), generator);
+  return StandaloneMain((int)c_args.size(), c_args.data(), generator);
 };
 
 }  // namespace codegen

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -19,11 +19,11 @@ namespace pb = google::protobuf;
 //
 // This function extracts the relevant file names (those, which match the
 // package) from the set of descriptors.
-bool ExtractFileNames(const std::vector<std::string>& desc_sets,
-                      const std::vector<std::string>& packages,
+bool ExtractFileNames(std::vector<std::string> const& desc_sets,
+                      std::vector<std::string> const& packages,
                       std::vector<std::string>& filenames,
                       std::string* error_msg) {
-  for (const std::string& desc_set : desc_sets) {
+  for (auto const& desc_set : desc_sets) {
     if (desc_set.empty()) {
       continue;
     }
@@ -43,7 +43,7 @@ bool ExtractFileNames(const std::vector<std::string>& desc_sets,
     }
 
     for (int i = 0; i < bin_desc_set.file_size(); i++) {
-      const auto& fl = bin_desc_set.file(i);
+      auto const& fl = bin_desc_set.file(i);
       auto iter = std::find(packages.begin(), packages.end(), fl.package());
       if (iter != packages.end()) {
         filenames.emplace_back(fl.name());
@@ -54,13 +54,13 @@ bool ExtractFileNames(const std::vector<std::string>& desc_sets,
   return true;
 }
 
-void ParseDelimitedArg(const std::string& arg,
+void ParseDelimitedArg(std::string const& arg,
                        std::vector<std::string>& tokens) {
   // Linux will use ':' and Windows will use ';' as the the delimiter.
   // Accept both as valid delimiters (not allowed to be used simultaneously).
-  const char* delimiters = ":;";
+  char const* delimiters = ":;";
   size_t p0 = 0;
-  for (const char* d = delimiters; *d != '\0' && tokens.empty(); d++) {
+  for (char const* d = delimiters; *d != '\0' && tokens.empty(); d++) {
     p0 = 0;
     for (size_t p = arg.find(*d, 0); p != std::string::npos;
          p0 = p + 1, p = arg.find(*d, p0)) {
@@ -84,15 +84,15 @@ void ParseDelimitedArg(const std::string& arg,
 //   this is especially useful for folder operations, since standard library
 //   below C++17 does not have folder I/O abstraction whatsoever.
 //
-bool ConvertCommandLineArgs(int argc, const char* const argv[],
+bool ConvertCommandLineArgs(int argc, char const* const argv[],
                             std::vector<std::string>& args,
                             std::string* error_msg) {
   // GAPIC Generator Standalone arguments
-  const std::string desc_arg("--descriptor");
-  const std::string output_arg("--output");
-  const std::string package_arg("--package");
+  std::string const desc_arg("--descriptor");
+  std::string const output_arg("--output");
+  std::string const package_arg("--package");
 
-  const std::string desc_set_in_arg("--descriptor_set_in=");
+  std::string const desc_set_in_arg("--descriptor_set_in=");
 
   std::vector<std::string> desc_set_in;
   std::vector<std::string> packages;
@@ -105,8 +105,8 @@ bool ConvertCommandLineArgs(int argc, const char* const argv[],
       continue;
     }
 
-    const std::string& arg_name = arg.substr(0, pos);
-    const std::string& arg_val = arg.substr(pos + 1, arg.size() - pos);
+    std::string const& arg_name = arg.substr(0, pos);
+    std::string const& arg_val = arg.substr(pos + 1, arg.size() - pos);
 
     if (arg_name == desc_arg || arg_name == desc_set_in_arg) {
       args.emplace_back(desc_set_in_arg + arg_val);
@@ -132,7 +132,7 @@ bool ConvertCommandLineArgs(int argc, const char* const argv[],
   return true;
 }
 
-int StandaloneMain(int argc, const char* const argv[],
+int StandaloneMain(int argc, char const* const argv[],
                    google::protobuf::compiler::CodeGenerator* generator) {
   std::string error_msg;
   std::vector<std::string> args;
@@ -141,26 +141,26 @@ int StandaloneMain(int argc, const char* const argv[],
   pb::compiler::CommandLineInterface cli;
   cli.RegisterGenerator("--cpp_gapic_out", generator, "GAPIC C++ Generator");
 
-  std::vector<const char*> c_args;
+  std::vector<char const*> c_args;
   c_args.reserve(args.size());
-  for (const std::string& arg : args) {
+  for (auto const& arg : args) {
     c_args.push_back(arg.c_str());
   }
 
   return cli.Run((int)args.size(), c_args.data());
 }
 
-int StandaloneMain(const std::vector<std::string>& descriptors,
-                   const std::string& package, const std::string& output,
+int StandaloneMain(std::vector<std::string> const& descriptors,
+                   std::string const& package, std::string const& output,
                    google::protobuf::compiler::CodeGenerator* generator) {
   std::string desc_set_in_arg("--descriptor=");
-  for (const std::string& desc_set : descriptors) {
+  for (auto const& desc_set : descriptors) {
     desc_set_in_arg += desc_set + ":";
   }
   std::string package_arg("--package=" + package);
   std::string output_arg("--output=" + output);
 
-  std::vector<const char*> c_args = {"<ignored>", desc_set_in_arg.c_str(),
+  std::vector<char const*> c_args = {"<ignored>", desc_set_in_arg.c_str(),
                                      package_arg.c_str(), output_arg.c_str()};
 
   return StandaloneMain((int)c_args.size(), c_args.data(), generator);

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -1,0 +1,180 @@
+#include <standalone.h>
+#include <fstream>
+
+#include <google/protobuf/compiler/command_line_interface.h>
+#include <google/protobuf/stubs/io_win32.h>
+#include <gapic_generator.h>
+
+namespace google {
+namespace api {
+namespace codegen {
+
+namespace pb = google::protobuf;
+
+// GAPIC Standalone expects proto package as an argument. It defines the API
+// for which the GAPIC code must be generated for (i.e. to distinguish between
+// common proto descriptors and the actual API descriptors). Protobuf compiler
+// and the corresponding google::protobuf::CommandLineInterface expect the list
+// of the API-specific .proto files instead.
+//
+// This function extracts the relevant file names (those, which match the
+// package) from the set of descriptors.
+bool ExtractFileNames(
+    const std::vector<std::string>& desc_sets,
+    const std::vector<std::string>& packages,
+    std::vector<std::string>& filenames,
+    std::string* error_msg) {
+
+  for (const std::string& desc_set : desc_sets) {
+    if (desc_set.empty()) {
+      continue;
+    }
+
+    std::ifstream fstr(desc_set);
+    if (!fstr) {
+      *error_msg = "Could not open file " + desc_set;
+      return false;
+    }
+
+    pb::FileDescriptorSet bin_desc_set;
+    bool parse_result = bin_desc_set.ParseFromIstream(&fstr);
+
+    fstr.close();
+    if (!parse_result) {
+      return false;
+    }
+
+    for (int i = 0; i < bin_desc_set.file_size(); i++) {
+      const auto& fl = bin_desc_set.file(i);
+      auto iter = std::find(packages.begin(), packages.end(), fl.package());
+      if (iter != packages.end()) {
+        filenames.emplace_back(fl.name());
+      }
+    }
+  }
+
+  return true;
+}
+
+void ParseDelimitedArg(const std::string& arg,
+                       std::vector<std::string>& tokens) {
+  // Linux will use ':' and Windows will use ';' as the the delimiter.
+  // Accept both as valid delimiters (not allowed to be used simultaneously).
+  const char* delimiters = ":;";
+  size_t p0 = 0;
+  for (const char* d = delimiters; *d != '\0' && tokens.empty(); d++) {
+    p0 = 0;
+    for (size_t p = arg.find(*d, 0);
+         p != std::string::npos;
+         p0 = p + 1, p = arg.find(*d, p0)) {
+      tokens.emplace_back(arg.substr(p0, p - p0));
+    }
+  }
+  if (arg.size() > p0) {
+    tokens.emplace_back(arg.substr(p0, arg.size() - p0));
+  }
+}
+
+// Converts arguments from what is required by GAPIC generator standalone mode
+// specification (--descriptor, --package, --output) to what is understood by
+// google::protobuf::CommandLineInterface. CommandLineInterface seems like the
+// preferred way of writing GAPIC generator in C++:
+// - it is what is used by protoc main() itself;
+// - it does not spawn a new subprocess if the generator was explicitly
+//   registered by CommandLineInterface::RegisterGenerator(), so it is
+//   performance efficient and good for debugging (runs in same process);
+// - it handles platform-specific file I/O (including writing into zip archive);
+//   this is especially useful for folder operations, since standard library
+//   below C++17 does not have folder I/O abstraction whatsoever.
+//
+bool ConvertCommandLineArgs(int argc,
+                            const char* const argv[],
+                            std::vector<std::string>& args,
+                            std::string* error_msg) {
+  // GAPIC Generator Standalone arguments
+  const std::string desc_arg("--descriptor");
+  const std::string output_arg("--output");
+  const std::string package_arg("--package");
+
+  const std::string desc_set_in_arg("--descriptor_set_in=");
+
+  std::vector<std::string> desc_set_in;
+  std::vector<std::string> packages;
+
+  for (int i = 0; i < argc; i++) {
+    std::string arg(argv[i]);
+    auto pos = arg.find('=', 0);
+    if (pos == std::string::npos) {
+      args.emplace_back(arg);
+      continue;
+    }
+
+    const std::string& arg_name = arg.substr(0, pos);
+    const std::string& arg_val = arg.substr(pos + 1, arg.size() - pos);
+
+    if (arg_name == desc_arg || arg_name == desc_set_in_arg) {
+      args.emplace_back(desc_set_in_arg + arg_val);
+      ParseDelimitedArg(arg_val, desc_set_in);
+    } else if (arg_name == output_arg) {
+      args.emplace_back("--cpp_gapic_out=" + arg_val);
+    } else if (arg_name == package_arg) {
+      ParseDelimitedArg(arg_val, packages);
+    } else {
+      args.emplace_back(arg);
+    }
+  }
+
+  if (!desc_set_in.empty()) {
+    std::vector<std::string> file_names;
+    if (!ExtractFileNames(desc_set_in, packages, file_names, error_msg)) {
+      return false;
+    }
+    args.insert(args.end(),
+                std::make_move_iterator(file_names.begin()),
+                std::make_move_iterator(file_names.end()));
+  }
+
+  return true;
+}
+
+int StandaloneMain(int argc,
+                   const char* const argv[],
+                   google::protobuf::compiler::CodeGenerator* generator) {
+  std::string error_msg;
+  std::vector<std::string> args;
+  ConvertCommandLineArgs(argc, argv, args, &error_msg);
+
+  pb::compiler::CommandLineInterface cli;
+  cli.RegisterGenerator("--cpp_gapic_out", generator, "GAPIC C++ Generator");
+
+  std::vector<const char*> c_args;
+  c_args.reserve(args.size());
+  for (const std::string& arg : args) {
+    c_args.push_back(arg.c_str());
+  }
+
+  return cli.Run((int) args.size(), c_args.data());
+}
+
+int StandaloneMain(const std::vector<std::string>& descriptors,
+                   const std::string& package,
+                   const std::string& output,
+                   google::protobuf::compiler::CodeGenerator* generator) {
+  std::string desc_set_in_arg("--descriptor=");
+  for (const std::string& desc_set : descriptors) {
+    desc_set_in_arg += desc_set + ":";
+  }
+  std::string package_arg("--package=" + package);
+  std::string output_arg("--output=" + output);
+
+  std::vector<const char*> c_args = {"<ignored>",
+                                     desc_set_in_arg.c_str(),
+                                     package_arg.c_str(),
+                                     output_arg.c_str()};
+
+  return StandaloneMain((int) c_args.size(), c_args.data(), generator);
+};
+
+}  // namespace codegen
+}  // namespace api
+}  // namespace google

--- a/generator/standalone.h
+++ b/generator/standalone.h
@@ -1,0 +1,23 @@
+#ifndef GENERATOR_STANDALONE_H_
+#define GENERATOR_STANDALONE_H_
+
+#include <google/protobuf/compiler/plugin.h>
+#include <google/protobuf/compiler/plugin.pb.h>
+
+namespace google {
+namespace api {
+namespace codegen {
+
+int StandaloneMain(int argc,
+                   const char* const argv[],
+                   google::protobuf::compiler::CodeGenerator* generator);
+
+int StandaloneMain(const std::vector<std::string>& descriptors,
+                   const std::string& package,
+                   const std::string& output,
+                   google::protobuf::compiler::CodeGenerator* generator);
+
+}  // namespace google
+}  // namespace api
+}  // namespace codegen
+#endif  // GENERATOR_STANDALONE_H_

--- a/generator/standalone.h
+++ b/generator/standalone.h
@@ -1,5 +1,5 @@
-#ifndef GENERATOR_STANDALONE_H_
-#define GENERATOR_STANDALONE_H_
+#ifndef GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_
+#define GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_
 
 #include <google/protobuf/compiler/plugin.h>
 #include <google/protobuf/compiler/plugin.pb.h>
@@ -8,16 +8,14 @@ namespace google {
 namespace api {
 namespace codegen {
 
-int StandaloneMain(int argc,
-                   const char* const argv[],
+int StandaloneMain(int argc, const char* const argv[],
                    google::protobuf::compiler::CodeGenerator* generator);
 
 int StandaloneMain(const std::vector<std::string>& descriptors,
-                   const std::string& package,
-                   const std::string& output,
+                   const std::string& package, const std::string& output,
                    google::protobuf::compiler::CodeGenerator* generator);
 
-}  // namespace google
-}  // namespace api
 }  // namespace codegen
-#endif  // GENERATOR_STANDALONE_H_
+}  // namespace api
+}  // namespace google
+#endif  // GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_

--- a/generator/testdata/BUILD.bazel
+++ b/generator/testdata/BUILD.bazel
@@ -1,0 +1,19 @@
+proto_library(
+    name = "library_proto",
+    srcs = ["library.proto"],
+    deps = ["@api_common_protos//google/api:client_proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "library_cc_proto",
+    deps = [":library_proto"],
+    visibility = ["//visibility:public"],
+)
+
+
+filegroup(
+    name = "library_service_baseline",
+    srcs = glob(["google/example/library/v1/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -20,7 +20,6 @@ def com_google_gapic_generator_cpp_repositories():
     _maybe(
         http_archive,
         name = "absl",
-        sha256 = "e2b53bfb685f5d4130b84c4f3050c81bf48c497614dc85d91dbd3ed9129bce6d",
         strip_prefix = "abseil-cpp-20181200",
         urls = ["https://github.com/abseil/abseil-cpp/archive/20181200.tar.gz"]
     )
@@ -28,15 +27,13 @@ def com_google_gapic_generator_cpp_repositories():
     _maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
-        strip_prefix = "protobuf-3.6.1.3",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"]
+        strip_prefix = "protobuf-3.7.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.7.1.tar.gz"]
     )
 
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
         strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"]
     )
@@ -45,15 +42,19 @@ def com_google_gapic_generator_cpp_repositories():
         http_archive,
         name = "net_zlib",
         build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         strip_prefix = "zlib-1.2.11",
         urls = ["https://zlib.net/zlib-1.2.11.tar.gz"]
     )
 
     _maybe(
+        native.bind,
+        name = "zlib",
+        actual = "@net_zlib//:zlib",
+    )
+
+    _maybe(
         http_archive,
         name = "api_common_protos",
-        sha256 = "70f02f98cd48367359740dd73d0bef1020181ae85c1045bce6799ae35097ae70",
         strip_prefix = "api-common-protos-87185dfffad4afa5a33a8c153f0e1ea53b4f85dc",
         urls = ["https://github.com/googleapis/api-common-protos/archive/87185dfffad4afa5a33a8c153f0e1ea53b4f85dc.tar.gz"]
     )
@@ -61,21 +62,9 @@ def com_google_gapic_generator_cpp_repositories():
     _maybe(
         http_archive,
         name = "gtest",
-        sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
         strip_prefix = "googletest-release-1.8.1",
         urls = ["https://github.com/google/googletest/archive/release-1.8.1.tar.gz"]
     )
-
-
-def com_google_gapic_generator_cpp_gax_repositories():
-    _maybe(
-        http_archive,
-        name = "com_github_grpc_grpc",
-        sha256 = "069a52a166382dd7b99bf8e7e805f6af40d797cfcee5f80e530ca3fc75fd06e2",
-        strip_prefix = "grpc-1.18.0",
-        urls = ["https://github.com/grpc/grpc/archive/v1.18.0.tar.gz"]
-    )
-
 
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():


### PR DESCRIPTION
This is a prerequisite for cc_gapic_library rule (will be submitted as a separate PR).

Most of the pr is `#include` changes. For actual changes please check the following files:
- `standalone.cc/standalone.h`
- `main.cc`
- `gapic_generator_unittest.cc`
- `BUILD.bazel`
- `gax/BUILD.bazel`
- `gax/repositories.bzl`
- `generator/testdata/BUILD.bazel`

Plus various small refactorings.

This includes:
1) "Fix" `#include` statements for external dependencies (`protobuf` and `gtest`): use `< >` instead of `" "`, also shorten path and conform to how it is done in protobuf repository itself (i.e. seems like and idiomatic way of making the imports). This also allows to get rid from `src/` prefix in the imports.
2) Gapic generator main binary can be executed in a plugin and a standalone mode (if command line args are provided, standalone mode is assumed automatically).
3) Standalone mode accepts standalone args according to the stand-alone interface spec:
    `--descriptor` - a list of descriptor sets (delimited with ':' or ';' character) (the spec does not require list, but accepting list is an extension, which still conforms to the spec);
    `--package` - a list (delimited with ':' or ';') which defines the proto packages designated for generation (to distinguish between common protos and actual api-specific protos, both of which must be specified in --descriptor); ability to specify a list is an extension to the spec;
    `--output` - the output folder (also supports outputting to zip archive, if output ends with .zip or .jar, this is an extension to the spec).
4) Refactor `BUILD.bazel` files and package structure.
5) Rename plugin binary to `protoc-gen-cpp_gapic` (to conform to spec and simplify usage as a plugin).
6) Refactor `gapic_generator_unittest.cc` (it will be simplified further, once `cc_gapic_library` is submitted)
7) Move gax-related repositories.bzl portion to its own `gax/repositories.bzl`