### PR TITLE
Use gax types in GAPIC client stub method signatures

### DIFF
--- a/gax/status.cc
+++ b/gax/status.cc
@@ -69,5 +69,9 @@ std::ostream& operator<<(std::ostream& os, Status const& rhs) {
   return os << rhs.message() << " [" << rhs.code() << "]";
 }
 
+Status GrpcStatusToGaxStatus(grpc::Status s) {
+  return Status(static_cast<StatusCode>(s.error_code()), s.error_message());
+}
+
 }  // namespace gax
 }  // namespace google

--- a/gax/status.h
+++ b/gax/status.h
@@ -15,6 +15,8 @@
 #ifndef GAPIC_GENERATOR_CPP_GAX_STATUS_H_
 #define GAPIC_GENERATOR_CPP_GAX_STATUS_H_
 
+#include "grpcpp/impl/codegen/status.h"
+
 #include <ostream>
 #include <string>
 
@@ -89,6 +91,8 @@ class Status {
 std::string StatusCodeToString(StatusCode code);
 std::ostream& operator<<(std::ostream& os, StatusCode code);
 std::ostream& operator<<(std::ostream& os, Status const& rhs);
+
+Status GrpcStatusToGaxStatus(grpc::Status s);
 
 }  // namespace gax
 }  // namespace google

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -73,7 +73,7 @@ bool GenerateClientCC(pb::ServiceDescriptor const* service,
       "$request_object$ const& request) {\n"
       "  // TODO: actual useful work, e.g. retry, backoff, metadata, "
       "pagination, etc.\n"
-      "  google::gax::CallContext context($method_name$_info_);\n"
+      "  google::gax::CallContext context($method_name_snake$_info);\n"
       "  $response_object$ response;\n"
       "  google::gax::Status status = stub_->$method_name$(context, request, "
       "&response);\n"
@@ -88,7 +88,7 @@ bool GenerateClientCC(pb::ServiceDescriptor const* service,
 
   DataModel::PrintMethods(
       service, vars, p,
-      "constexpr MethodInfo $class_name$::$method_name$_info_;\n",
+      "constexpr MethodInfo $class_name$::$method_name_snake$_info;\n",
       NoStreamingPredicate);
 
   for (auto nspace : namespaces) {

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -36,7 +36,8 @@ std::vector<std::string> BuildClientCCIncludes(
           internal::ServiceNameToFilePath(service->name()), ".gapic.h")),
       LocalInclude(absl::StrCat(
           internal::ServiceNameToFilePath(service->name()), "_stub.gapic.h")),
-      LocalInclude("gax/status.h"), LocalInclude("gax/status_or.h"),
+      LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
+      LocalInclude("gax/status_or.h"),
   };
 }
 
@@ -67,22 +68,27 @@ bool GenerateClientCC(pb::ServiceDescriptor const* service,
 
   DataModel::PrintMethods(
       service, vars, p,
-      "gax::StatusOr<$response_object$>\n"
+      "google::gax::StatusOr<$response_object$>\n"
       "$class_name$::$method_name$(\n"
       "$request_object$ const& request) {\n"
       "  // TODO: actual useful work, e.g. retry, backoff, metadata, "
       "pagination, etc.\n"
-      "  grpc::ClientContext context;\n"
+      "  google::gax::CallContext context($method_name$_info_);\n"
       "  $response_object$ response;\n"
-      "  grpc::Status status = stub_->$method_name$(&context, request, "
+      "  google::gax::Status status = stub_->$method_name$(context, request, "
       "&response);\n"
-      "  if (status.ok()) {\n"
+      "  if (status.IsOk()) {\n"
       "    return response;\n"
       "  } else {\n"
-      "    return gax::GrpcStatusToGaxStatus(status);\n"
+      "    return status;\n"
       "  }\n"
       "}\n"
       "\n",
+      NoStreamingPredicate);
+
+  DataModel::PrintMethods(
+      service, vars, p,
+      "constexpr MethodInfo $class_name$::$method_name$_info_;\n",
       NoStreamingPredicate);
 
   for (auto nspace : namespaces) {

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -115,7 +115,6 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
            "  std::unique_ptr<google::gax::RetryPolicy> retry_policy_;\n"
            "  std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;\n"
            "\n"
-           "\n"
            "  // Note: conservatively assume no methods are idempotent.\n"
            "  //       This will eventually be set from annotations.\n");
 

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -114,13 +114,14 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
            "  std::shared_ptr<$stub_class_name$> stub_;\n"
            "  std::unique_ptr<google::gax::RetryPolicy> retry_policy_;\n"
            "  std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;\n"
-           "\n");
+           "\n"
+           "\n"
+           "  // Note: conservatively assume no methods are idempotent.\n"
+           "  //       This will eventually be set from annotations.\n");
 
   DataModel::PrintMethods(
       service, vars, p,
-      "  // Note: conservatively assume no methods are idempotent.\n"
-      "  //       This will eventually be set from annotations.\n"
-      "  static constexpr google::gax::MethodInfo $method_name$_info_ = "
+      "  static constexpr google::gax::MethodInfo $method_name_snake$_info = "
       "{\"$method_name$\", google::gax::MethodInfo::RpcType::NORMAL_RPC};\n",
       NoStreamingPredicate);
 

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -89,7 +89,7 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
            "\n");
 
   DataModel::PrintMethods(service, vars, p,
-                          "  gax::StatusOr<$response_object$> \n"
+                          "  google::gax::StatusOr<$response_object$> \n"
                           "  $method_name$($request_object$ const& request);\n"
                           "\n",
                           NoStreamingPredicate);
@@ -97,10 +97,10 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
   p->Print(vars,
            "\n"
            " private:\n"
-           "  void ChangePolicy(gax::RetryPolicy const& policy) {\n"
+           "  void ChangePolicy(google::gax::RetryPolicy const& policy) {\n"
            "    retry_policy_ = policy.clone();\n"
            "  }\n"
-           "  void ChangePolicy(gax::BackoffPolicy const& policy) {\n"
+           "  void ChangePolicy(google::gax::BackoffPolicy const& policy) {\n"
            "    backoff_policy_ = policy.clone();\n"
            "  }\n"
            "  void ChangePolicies() {}\n"
@@ -112,8 +112,19 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
            "  }\n"
            "\n"
            "  std::shared_ptr<$stub_class_name$> stub_;\n"
-           "  std::unique_ptr<gax::RetryPolicy> retry_policy_;\n"
-           "  std::unique_ptr<gax::BackoffPolicy> backoff_policy_;\n"
+           "  std::unique_ptr<google::gax::RetryPolicy> retry_policy_;\n"
+           "  std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;\n"
+           "\n");
+
+  DataModel::PrintMethods(
+      service, vars, p,
+      "  // Note: conservatively assume no methods are idempotent.\n"
+      "  //       This will eventually be set from annotations.\n"
+      "  static constexpr google::gax::MethodInfo $method_name$_info_ = "
+      "{\"$method_name$\", google::gax::MethodInfo::RpcType::NORMAL_RPC};\n",
+      NoStreamingPredicate);
+
+  p->Print(vars,
            "}; // $class_name$\n"
            "\n");
 

--- a/generator/internal/data_model.h
+++ b/generator/internal/data_model.h
@@ -56,6 +56,7 @@ struct DataModel {
   static void SetMethodVars(pb::MethodDescriptor const* method,
                             std::map<std::string, std::string>& vars) {
     vars["method_name"] = method->name();
+    vars["method_name_snake"] = CamelCaseToSnakeCase(method->name());
     vars["request_object"] =
         internal::ProtoNameToCppName(method->input_type()->full_name());
     vars["response_object"] =

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "data_model.h"
+#include "gapic_utils.h"
 #include "printer.h"
 #include "stub_header_generator.h"
 #include <google/protobuf/descriptor.h>
@@ -29,10 +30,10 @@ namespace internal {
 
 std::vector<std::string> BuildClientStubHeaderIncludes(
     pb::ServiceDescriptor const* service) {
-  return {
-      LocalInclude(absl::StrCat(service->name(), ".pb.h")),
-      LocalInclude("grpcpp/client_context.h"), LocalInclude("grpc/status.h"),
-  };
+  return {LocalInclude(absl::StrCat(service->name(), ".pb.h")),
+          LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
+          LocalInclude("grpcpp/security/credentials.h"),
+          SystemInclude("memory")};
 }
 
 std::vector<std::string> BuildClientStubHeaderNamespaces(
@@ -69,13 +70,13 @@ bool GenerateClientStubHeader(pb::ServiceDescriptor const* service,
            "class $stub_class_name$ {\n"
            " public:\n");
 
-  DataModel::PrintMethods(
-      service, vars, p,
-      "  virtual grpc::Status $method_name$(grpc::ClientContext* context,\n"
-      "    $request_object$ const& request,\n"
-      "    $response_object$* response);\n"
-      "\n",
-      NoStreamingPredicate);
+  DataModel::PrintMethods(service, vars, p,
+                          "  virtual google::gax::Status $method_name$("
+                          "google::gax::CallContext& context,\n"
+                          "    $request_object$ const& request,\n"
+                          "    $response_object$* response);\n"
+                          "\n",
+                          NoStreamingPredicate);
 
   p->Print(vars,
            "  virtual ~$stub_class_name$() = 0;\n"

--- a/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
@@ -11,7 +11,7 @@ google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::CreateBook(
 ::google::example::library::v1::CreateBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(CreateBook_info_);
+  google::gax::CallContext context(create_book_info);
   ::google::example::library::v1::Book response;
   google::gax::Status status = stub_->CreateBook(context, request, &response);
   if (status.IsOk()) {
@@ -25,7 +25,7 @@ google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::GetBook(
 ::google::example::library::v1::GetBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(GetBook_info_);
+  google::gax::CallContext context(get_book_info);
   ::google::example::library::v1::Book response;
   google::gax::Status status = stub_->GetBook(context, request, &response);
   if (status.IsOk()) {
@@ -39,7 +39,7 @@ google::gax::StatusOr<::google::example::library::v1::ListBooksResponse>
 LibraryService::ListBooks(
 ::google::example::library::v1::ListBooksRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(ListBooks_info_);
+  google::gax::CallContext context(list_books_info);
   ::google::example::library::v1::ListBooksResponse response;
   google::gax::Status status = stub_->ListBooks(context, request, &response);
   if (status.IsOk()) {
@@ -53,7 +53,7 @@ google::gax::StatusOr<::google::example::library::v1::Empty>
 LibraryService::DeleteBook(
 ::google::example::library::v1::DeleteBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(DeleteBook_info_);
+  google::gax::CallContext context(delete_book_info);
   ::google::example::library::v1::Empty response;
   google::gax::Status status = stub_->DeleteBook(context, request, &response);
   if (status.IsOk()) {
@@ -67,7 +67,7 @@ google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::UpdateBook(
 ::google::example::library::v1::UpdateBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(UpdateBook_info_);
+  google::gax::CallContext context(update_book_info);
   ::google::example::library::v1::Book response;
   google::gax::Status status = stub_->UpdateBook(context, request, &response);
   if (status.IsOk()) {
@@ -81,7 +81,7 @@ google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::GetBigBook(
 ::google::example::library::v1::GetBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  google::gax::CallContext context(GetBigBook_info_);
+  google::gax::CallContext context(get_big_book_info);
   ::google::example::library::v1::Book response;
   google::gax::Status status = stub_->GetBigBook(context, request, &response);
   if (status.IsOk()) {
@@ -91,9 +91,9 @@ LibraryService::GetBigBook(
   }
 }
 
-constexpr MethodInfo LibraryService::CreateBook_info_;
-constexpr MethodInfo LibraryService::GetBook_info_;
-constexpr MethodInfo LibraryService::ListBooks_info_;
-constexpr MethodInfo LibraryService::DeleteBook_info_;
-constexpr MethodInfo LibraryService::UpdateBook_info_;
-constexpr MethodInfo LibraryService::GetBigBook_info_;
+constexpr MethodInfo LibraryService::create_book_info;
+constexpr MethodInfo LibraryService::get_book_info;
+constexpr MethodInfo LibraryService::list_books_info;
+constexpr MethodInfo LibraryService::delete_book_info;
+constexpr MethodInfo LibraryService::update_book_info;
+constexpr MethodInfo LibraryService::get_big_book_info;

--- a/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
@@ -3,90 +3,97 @@
 // source: generator/testdata/library.proto
 #include "library_service.gapic.h"
 #include "library_service_stub.gapic.h"
+#include "gax/call_context.h"
 #include "gax/status.h"
 #include "gax/status_or.h"
 
-gax::StatusOr<::google::example::library::v1::Book>
+google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::CreateBook(
 ::google::example::library::v1::CreateBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(CreateBook_info_);
   ::google::example::library::v1::Book response;
-  grpc::Status status = stub_->CreateBook(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->CreateBook(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
-gax::StatusOr<::google::example::library::v1::Book>
+google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::GetBook(
 ::google::example::library::v1::GetBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(GetBook_info_);
   ::google::example::library::v1::Book response;
-  grpc::Status status = stub_->GetBook(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->GetBook(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
-gax::StatusOr<::google::example::library::v1::ListBooksResponse>
+google::gax::StatusOr<::google::example::library::v1::ListBooksResponse>
 LibraryService::ListBooks(
 ::google::example::library::v1::ListBooksRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(ListBooks_info_);
   ::google::example::library::v1::ListBooksResponse response;
-  grpc::Status status = stub_->ListBooks(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->ListBooks(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
-gax::StatusOr<::google::example::library::v1::Empty>
+google::gax::StatusOr<::google::example::library::v1::Empty>
 LibraryService::DeleteBook(
 ::google::example::library::v1::DeleteBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(DeleteBook_info_);
   ::google::example::library::v1::Empty response;
-  grpc::Status status = stub_->DeleteBook(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->DeleteBook(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
-gax::StatusOr<::google::example::library::v1::Book>
+google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::UpdateBook(
 ::google::example::library::v1::UpdateBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(UpdateBook_info_);
   ::google::example::library::v1::Book response;
-  grpc::Status status = stub_->UpdateBook(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->UpdateBook(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
-gax::StatusOr<::google::example::library::v1::Book>
+google::gax::StatusOr<::google::example::library::v1::Book>
 LibraryService::GetBigBook(
 ::google::example::library::v1::GetBookRequest const& request) {
   // TODO: actual useful work, e.g. retry, backoff, metadata, pagination, etc.
-  grpc::ClientContext context;
+  google::gax::CallContext context(GetBigBook_info_);
   ::google::example::library::v1::Book response;
-  grpc::Status status = stub_->GetBigBook(&context, request, &response);
-  if (status.ok()) {
+  google::gax::Status status = stub_->GetBigBook(context, request, &response);
+  if (status.IsOk()) {
     return response;
   } else {
-    return gax::GrpcStatusToGaxStatus(status);
+    return status;
   }
 }
 
+constexpr MethodInfo LibraryService::CreateBook_info_;
+constexpr MethodInfo LibraryService::GetBook_info_;
+constexpr MethodInfo LibraryService::ListBooks_info_;
+constexpr MethodInfo LibraryService::DeleteBook_info_;
+constexpr MethodInfo LibraryService::UpdateBook_info_;
+constexpr MethodInfo LibraryService::GetBigBook_info_;

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -28,30 +28,30 @@ class LibraryService final {
 
   std::shared_ptr<LibraryServiceStub> Stub() { return stub_; }
 
-  gax::StatusOr<::google::example::library::v1::Book> 
+  google::gax::StatusOr<::google::example::library::v1::Book> 
   CreateBook(::google::example::library::v1::CreateBookRequest const& request);
 
-  gax::StatusOr<::google::example::library::v1::Book> 
+  google::gax::StatusOr<::google::example::library::v1::Book> 
   GetBook(::google::example::library::v1::GetBookRequest const& request);
 
-  gax::StatusOr<::google::example::library::v1::ListBooksResponse> 
+  google::gax::StatusOr<::google::example::library::v1::ListBooksResponse> 
   ListBooks(::google::example::library::v1::ListBooksRequest const& request);
 
-  gax::StatusOr<::google::example::library::v1::Empty> 
+  google::gax::StatusOr<::google::example::library::v1::Empty> 
   DeleteBook(::google::example::library::v1::DeleteBookRequest const& request);
 
-  gax::StatusOr<::google::example::library::v1::Book> 
+  google::gax::StatusOr<::google::example::library::v1::Book> 
   UpdateBook(::google::example::library::v1::UpdateBookRequest const& request);
 
-  gax::StatusOr<::google::example::library::v1::Book> 
+  google::gax::StatusOr<::google::example::library::v1::Book> 
   GetBigBook(::google::example::library::v1::GetBookRequest const& request);
 
 
  private:
-  void ChangePolicy(gax::RetryPolicy const& policy) {
+  void ChangePolicy(google::gax::RetryPolicy const& policy) {
     retry_policy_ = policy.clone();
   }
-  void ChangePolicy(gax::BackoffPolicy const& policy) {
+  void ChangePolicy(google::gax::BackoffPolicy const& policy) {
     backoff_policy_ = policy.clone();
   }
   void ChangePolicies() {}
@@ -63,8 +63,27 @@ class LibraryService final {
   }
 
   std::shared_ptr<LibraryServiceStub> stub_;
-  std::unique_ptr<gax::RetryPolicy> retry_policy_;
-  std::unique_ptr<gax::BackoffPolicy> backoff_policy_;
+  std::unique_ptr<google::gax::RetryPolicy> retry_policy_;
+  std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;
+
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo CreateBook_info_ = {"CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo GetBook_info_ = {"GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo ListBooks_info_ = {"ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo DeleteBook_info_ = {"DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo UpdateBook_info_ = {"UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  // Note: conservatively assume no methods are idempotent.
+  //       This will eventually be set from annotations.
+  static constexpr google::gax::MethodInfo GetBigBook_info_ = {"GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
 }; // LibraryService
 
 #endif // LibraryService_H_

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -66,24 +66,15 @@ class LibraryService final {
   std::unique_ptr<google::gax::RetryPolicy> retry_policy_;
   std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;
 
+
   // Note: conservatively assume no methods are idempotent.
   //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo CreateBook_info_ = {"CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  // Note: conservatively assume no methods are idempotent.
-  //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo GetBook_info_ = {"GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  // Note: conservatively assume no methods are idempotent.
-  //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo ListBooks_info_ = {"ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  // Note: conservatively assume no methods are idempotent.
-  //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo DeleteBook_info_ = {"DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  // Note: conservatively assume no methods are idempotent.
-  //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo UpdateBook_info_ = {"UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  // Note: conservatively assume no methods are idempotent.
-  //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo GetBigBook_info_ = {"GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo create_book_info = {"CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo get_book_info = {"GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo list_books_info = {"ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo delete_book_info = {"DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo update_book_info = {"UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo get_big_book_info = {"GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
 }; // LibraryService
 
 #endif // LibraryService_H_

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -66,7 +66,6 @@ class LibraryService final {
   std::unique_ptr<google::gax::RetryPolicy> retry_policy_;
   std::unique_ptr<google::gax::BackoffPolicy> backoff_policy_;
 
-
   // Note: conservatively assume no methods are idempotent.
   //       This will eventually be set from annotations.
   static constexpr google::gax::MethodInfo create_book_info = {"CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
@@ -3,60 +3,63 @@
 // source: generator/testdata/library.proto
 
 #include "library_service_stub.gapic.h"
+#include "gax/call_context.h"
+#include "gax/Status.h"
+#include "grpcpp/client_context.h"
 #include "grpcpp/channel.h"
 #include "grpcpp/create_channel.h"
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::CreateBook(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::CreateBookRequest const&,
   ::google::example::library::v1::Book*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "CreateBook not implemented");
 }
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::GetBook(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::GetBookRequest const&,
   ::google::example::library::v1::Book*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "GetBook not implemented");
 }
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::ListBooks(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::ListBooksRequest const&,
   ::google::example::library::v1::ListBooksResponse*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "ListBooks not implemented");
 }
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::DeleteBook(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::DeleteBookRequest const&,
   ::google::example::library::v1::Empty*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "DeleteBook not implemented");
 }
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::UpdateBook(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::UpdateBookRequest const&,
   ::google::example::library::v1::Book*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "UpdateBook not implemented");
 }
 
-grpc::Status
+google::gax::Status
 LibraryServiceStub::GetBigBook(
-  grpc::ClientContext*,
+  google::gax::CallContext&,
   ::google::example::library::v1::GetBookRequest const&,
   ::google::example::library::v1::Book*) {
-  return grpc::Status(grpc::StatusCode::kUnimplemented,
+  return google::gax::Status(google::gax::StatusCode::kUnimplemented,
     "GetBigBook not implemented");
 }
 
@@ -71,46 +74,58 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
   DefaultLibraryServiceStub(DefaultLibraryServiceStub const&) = delete;
   DefaultLibraryServiceStub& operator=(DefaultLibraryServiceStub const&) = delete;
 
-  grpc::Status
-  CreateBook(grpc::ClientContext* context,
+  google::gax::Status
+  CreateBook(google::gax::CallContext& context,
     ::google::example::library::v1::CreateBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
-    return grpc_stub_->CreateBook(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->CreateBook(&grpc_ctx, request, response));
   }
 
-  grpc::Status
-  GetBook(grpc::ClientContext* context,
+  google::gax::Status
+  GetBook(google::gax::CallContext& context,
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
-    return grpc_stub_->GetBook(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->GetBook(&grpc_ctx, request, response));
   }
 
-  grpc::Status
-  ListBooks(grpc::ClientContext* context,
+  google::gax::Status
+  ListBooks(google::gax::CallContext& context,
     ::google::example::library::v1::ListBooksRequest const& request,
     ::google::example::library::v1::ListBooksResponse* response) override {
-    return grpc_stub_->ListBooks(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->ListBooks(&grpc_ctx, request, response));
   }
 
-  grpc::Status
-  DeleteBook(grpc::ClientContext* context,
+  google::gax::Status
+  DeleteBook(google::gax::CallContext& context,
     ::google::example::library::v1::DeleteBookRequest const& request,
     ::google::example::library::v1::Empty* response) override {
-    return grpc_stub_->DeleteBook(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->DeleteBook(&grpc_ctx, request, response));
   }
 
-  grpc::Status
-  UpdateBook(grpc::ClientContext* context,
+  google::gax::Status
+  UpdateBook(google::gax::CallContext& context,
     ::google::example::library::v1::UpdateBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
-    return grpc_stub_->UpdateBook(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->UpdateBook(&grpc_ctx, request, response));
   }
 
-  grpc::Status
-  GetBigBook(grpc::ClientContext* context,
+  google::gax::Status
+  GetBigBook(google::gax::CallContext& context,
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
-    return grpc_stub_->GetBigBook(context, request, response);
+    grpc::ClientContext grpc_ctx;
+    context->PrepareGrpcContext(&grpc_context);
+    return google::gax::GrpcStatusToGaxStatus(grpc_stub_->GetBigBook(&grpc_ctx, request, response));
   }
 
  private:

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
@@ -5,32 +5,34 @@
 #define LibraryService_Stub_H_
 
 #include "LibraryService.pb.h"
-#include "grpcpp/client_context.h"
-#include "grpc/status.h"
+#include "gax/call_context.h"
+#include "gax/status.h"
+#include "grpcpp/security/credentials.h"
+#include <memory>
 
 class LibraryServiceStub {
  public:
-  virtual grpc::Status CreateBook(grpc::ClientContext* context,
+  virtual google::gax::Status CreateBook(google::gax::CallContext& context,
     ::google::example::library::v1::CreateBookRequest const& request,
     ::google::example::library::v1::Book* response);
 
-  virtual grpc::Status GetBook(grpc::ClientContext* context,
+  virtual google::gax::Status GetBook(google::gax::CallContext& context,
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response);
 
-  virtual grpc::Status ListBooks(grpc::ClientContext* context,
+  virtual google::gax::Status ListBooks(google::gax::CallContext& context,
     ::google::example::library::v1::ListBooksRequest const& request,
     ::google::example::library::v1::ListBooksResponse* response);
 
-  virtual grpc::Status DeleteBook(grpc::ClientContext* context,
+  virtual google::gax::Status DeleteBook(google::gax::CallContext& context,
     ::google::example::library::v1::DeleteBookRequest const& request,
     ::google::example::library::v1::Empty* response);
 
-  virtual grpc::Status UpdateBook(grpc::ClientContext* context,
+  virtual google::gax::Status UpdateBook(google::gax::CallContext& context,
     ::google::example::library::v1::UpdateBookRequest const& request,
     ::google::example::library::v1::Book* response);
 
-  virtual grpc::Status GetBigBook(grpc::ClientContext* context,
+  virtual google::gax::Status GetBigBook(google::gax::CallContext& context,
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response);
 


### PR DESCRIPTION
Applies s/grpc::ClientContext/gax::CallContext,
             s/grpc::Status/gax::Status

Fully qualify gax namespace to google::gax
Add a GrpcStatusToGaxStatus helper function

Add some necessary includes to generated files
Add autogenerated MethodInfo structs to abstract GAPIC clients.