### PR TITLE
Add Bazel Gapic Extensions for C++

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,16 +42,10 @@ grpc_deps()
 #
 # gapic-generator
 #
-#http_archive(
-#    name = "com_google_api_codegen",
-#    urls = ["https://github.com/googleapis/gapic-generator/archive/96c3c5a4c8397d4bd29a6abce861547a271383e1.zip"],
-#    strip_prefix = "gapic-generator-96c3c5a4c8397d4bd29a6abce861547a271383e1",
-#)
-
-#TODO: update once https://github.com/googleapis/gapic-generator/pull/2743 is merged
-local_repository(
+http_archive(
     name = "com_google_api_codegen",
-    path = "/usr/local/google/home/vam/_/projects/github/vam-google/gapic-generator",
+    urls = ["https://github.com/googleapis/gapic-generator/archive/025ebdbb3d14609be938900a538418858b0ecfb7.zip"],
+    strip_prefix = "gapic-generator-025ebdbb3d14609be938900a538418858b0ecfb7",
 )
 
 #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,10 +42,16 @@ grpc_deps()
 #
 # gapic-generator
 #
-http_archive(
+#http_archive(
+#    name = "com_google_api_codegen",
+#    urls = ["https://github.com/googleapis/gapic-generator/archive/96c3c5a4c8397d4bd29a6abce861547a271383e1.zip"],
+#    strip_prefix = "gapic-generator-96c3c5a4c8397d4bd29a6abce861547a271383e1",
+#)
+
+#TODO: update once https://github.com/googleapis/gapic-generator/pull/2743 is merged
+local_repository(
     name = "com_google_api_codegen",
-    urls = ["https://github.com/googleapis/gapic-generator/archive/96c3c5a4c8397d4bd29a6abce861547a271383e1.zip"],
-    strip_prefix = "gapic-generator-96c3c5a4c8397d4bd29a6abce861547a271383e1",
+    path = "/usr/local/google/home/vam/_/projects/github/vam-google/gapic-generator",
 )
 
 #

--- a/gax/repositories.bzl
+++ b/gax/repositories.bzl
@@ -15,11 +15,18 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_gapic_generator_cpp_gax_repositories():
+#    _maybe(
+#        http_archive,
+#        name = "com_github_grpc_grpc",
+#        strip_prefix = "grpc-1.18.0",
+#        urls = ["https://github.com/grpc/grpc/archive/v1.18.0.tar.gz"],
+#    )
+
+    #TODO: update once cc_grpc_library update is merged
     _maybe(
-        http_archive,
+        native.local_repository,
         name = "com_github_grpc_grpc",
-        strip_prefix = "grpc-1.18.0",
-        urls = ["https://github.com/grpc/grpc/archive/v1.18.0.tar.gz"],
+        path = "/usr/local/google/home/vam/_/projects/github/vam-google/grpc",
     )
 
     _maybe(

--- a/gax/repositories.bzl
+++ b/gax/repositories.bzl
@@ -15,18 +15,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_gapic_generator_cpp_gax_repositories():
-#    _maybe(
-#        http_archive,
-#        name = "com_github_grpc_grpc",
-#        strip_prefix = "grpc-1.18.0",
-#        urls = ["https://github.com/grpc/grpc/archive/v1.18.0.tar.gz"],
-#    )
-
-    #TODO: update once cc_grpc_library update is merged
     _maybe(
-        native.local_repository,
+        http_archive,
         name = "com_github_grpc_grpc",
-        path = "/usr/local/google/home/vam/_/projects/github/vam-google/grpc",
+        strip_prefix = "grpc-cc75d93818410e2b0edd0fa3009a6def9ac403ca",
+        urls = ["https://github.com/grpc/grpc/archive/cc75d93818410e2b0edd0fa3009a6def9ac403ca.tar.gz"],
     )
 
     _maybe(

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -54,6 +54,7 @@ cc_binary(
     srcs = ["main.cc"],
     includes = ["."],
     deps = [":gapic_generator"],
+    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -70,7 +70,7 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
 
     EXPECT_EQ(expected_file_content, actual_file_content)
         << "\nexpected_file: " << expected_file
-        << "\nactual_file: " << actual_file;
+        << "\nactual_file: " << actual_file_content;
   }
 }
 

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -70,7 +70,7 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
 
     EXPECT_EQ(expected_file_content, actual_file_content)
         << "\nexpected_file: " << expected_file
-        << "\nactual_file: " << actual_file_content;
+        << "\nactual_file: " << actual_file;
   }
 }
 

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -71,7 +71,9 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
     std::string const& expected_file_content = LoadContent(expected_file);
     std::string const& actual_file_content = LoadContent(actual_file);
 
-    EXPECT_EQ(expected_file_content, actual_file_content);
+    EXPECT_EQ(expected_file_content, actual_file_content)
+        << "\nexpected_file: " << expected_file
+        << "\nactual_file: " << actual_file;
   }
 }
 

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -86,10 +86,10 @@ bool GenerateClientCC(pb::ServiceDescriptor const* service,
       "\n",
       NoStreamingPredicate);
 
-  DataModel::PrintMethods(
-      service, vars, p,
-      "constexpr MethodInfo $class_name$::$method_name_snake$_info;\n",
-      NoStreamingPredicate);
+  DataModel::PrintMethods(service, vars, p,
+                          "constexpr google::gax::MethodInfo "
+                          "$class_name$::$method_name_snake$_info;\n",
+                          NoStreamingPredicate);
 
   for (auto nspace : namespaces) {
     p->Print("\n} // namespace $namespace$", "namespace", nspace);

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -35,7 +35,9 @@ std::vector<std::string> BuildClientHeaderIncludes(
       SystemInclude("memory"),
       LocalInclude(absl::StrCat(
           internal::ServiceNameToFilePath(service->name()), "_stub.gapic.h")),
-      LocalInclude(absl::StrCat(service->name(), ".pb.h")),
+      LocalInclude(absl::StrCat(
+          absl::StripSuffix(service->file()->name(), ".proto"), ".pb.h")),
+
       LocalInclude("gax/status_or.h"), LocalInclude("gax/retry_policy.h"),
       LocalInclude("gax/backoff_policy.h"),
   };

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -124,7 +124,7 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
       "  static constexpr google::gax::MethodInfo $method_name_snake$_info = {"
       "\n"
       "      \"$method_name$\", google::gax::MethodInfo::RpcType::NORMAL_RPC,\n"
-      "      google::gax::MethodInfo::Idempotency::IDEMPOTENT};\n",
+      "      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};\n",
       NoStreamingPredicate);
 
   p->Print(vars,

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -121,8 +121,10 @@ bool GenerateClientHeader(pb::ServiceDescriptor const* service,
 
   DataModel::PrintMethods(
       service, vars, p,
-      "  static constexpr google::gax::MethodInfo $method_name_snake$_info = "
-      "{\"$method_name$\", google::gax::MethodInfo::RpcType::NORMAL_RPC};\n",
+      "  static constexpr google::gax::MethodInfo $method_name_snake$_info = {"
+      "\n"
+      "      \"$method_name$\", google::gax::MethodInfo::RpcType::NORMAL_RPC,\n"
+      "      google::gax::MethodInfo::Idempotency::IDEMPOTENT};\n",
       NoStreamingPredicate);
 
   p->Print(vars,

--- a/generator/internal/stub_cc_generator.cc
+++ b/generator/internal/stub_cc_generator.cc
@@ -29,7 +29,7 @@ std::vector<std::string> BuildClientStubCCIncludes(
     pb::ServiceDescriptor const* service) {
   return {LocalInclude(absl::StrCat(CamelCaseToSnakeCase(service->name()),
                                     "_stub.gapic.h")),
-          LocalInclude("gax/call_context.h"), LocalInclude("gax/Status.h"),
+          LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
           LocalInclude("grpcpp/client_context.h"),
           LocalInclude("grpcpp/channel.h"),
           LocalInclude("grpcpp/create_channel.h")};

--- a/generator/internal/stub_cc_generator.cc
+++ b/generator/internal/stub_cc_generator.cc
@@ -27,12 +27,14 @@ namespace internal {
 
 std::vector<std::string> BuildClientStubCCIncludes(
     pb::ServiceDescriptor const* service) {
-  return {LocalInclude(absl::StrCat(CamelCaseToSnakeCase(service->name()),
-                                    "_stub.gapic.h")),
-          LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
-          LocalInclude("grpcpp/client_context.h"),
-          LocalInclude("grpcpp/channel.h"),
-          LocalInclude("grpcpp/create_channel.h")};
+  return {
+      LocalInclude(
+          absl::StrCat(CamelCaseToSnakeCase(service->name()), "_stub.gapic.h")),
+      LocalInclude(absl::StrCat(
+          absl::StripSuffix(service->file()->name(), ".proto"), ".grpc.pb.h")),
+      LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
+      LocalInclude("grpcpp/client_context.h"), LocalInclude("grpcpp/channel.h"),
+      LocalInclude("grpcpp/create_channel.h")};
 }
 
 std::vector<std::string> BuildClientStubCCNamespaces(
@@ -83,7 +85,7 @@ bool GenerateClientStubCC(pb::ServiceDescriptor const* service,
            "namespace {\n"
            "class Default$stub_class_name$ : public $stub_class_name$ {\n"
            " public:\n"
-           "  Default$stub_class_name$(std::unique_ptr<$class_name$::"
+           "  Default$stub_class_name$(std::unique_ptr<$grpc_stub_fqn$::"
            "StubInterface> grpc_stub)\n"
            "    : grpc_stub_(std::move(grpc_stub)) {}\n"
            "\n"
@@ -100,7 +102,7 @@ bool GenerateClientStubCC(pb::ServiceDescriptor const* service,
       "    $request_object$ const& request,\n"
       "    $response_object$* response) override {\n"
       "    grpc::ClientContext grpc_ctx;\n"
-      "    context->PrepareGrpcContext(&grpc_context);\n"
+      "    context.PrepareGrpcContext(&grpc_ctx);\n"
       "    return google::gax::GrpcStatusToGaxStatus("
       "grpc_stub_->$method_name$(&grpc_ctx, request, response));\n"
       "  }\n"

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -30,8 +30,8 @@ namespace internal {
 
 std::vector<std::string> BuildClientStubHeaderIncludes(
     pb::ServiceDescriptor const* service) {
-  return {LocalInclude(absl::StrCat(absl::StripSuffix(service->file()->name(),
-                                                      ".proto"), ".pb.h")),
+  return {LocalInclude(absl::StrCat(
+              absl::StripSuffix(service->file()->name(), ".proto"), ".pb.h")),
           LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
           LocalInclude("grpcpp/security/credentials.h"),
           SystemInclude("memory")};

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -30,7 +30,8 @@ namespace internal {
 
 std::vector<std::string> BuildClientStubHeaderIncludes(
     pb::ServiceDescriptor const* service) {
-  return {LocalInclude(absl::StrCat(service->name(), ".pb.h")),
+  return {LocalInclude(absl::StrCat(absl::StripSuffix(service->file()->name(),
+                                                      ".proto"), ".pb.h")),
           LocalInclude("gax/call_context.h"), LocalInclude("gax/status.h"),
           LocalInclude("grpcpp/security/credentials.h"),
           SystemInclude("memory")};

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -114,7 +114,7 @@ bool ConvertCommandLineArgs(int argc, char const* const argv[],
       return false;
     }
     args->insert(args->end(), std::make_move_iterator(file_names.begin()),
-                std::make_move_iterator(file_names.end()));
+                 std::make_move_iterator(file_names.end()));
   }
 
   return true;

--- a/generator/testdata/BUILD.bazel
+++ b/generator/testdata/BUILD.bazel
@@ -1,11 +1,12 @@
 load("//rules_gapic/cpp:cc_gapic.bzl", "cc_gapic_srcjar", "cc_gapic_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_library_with_info")
 
 proto_library(
     name = "library_proto",
     srcs = ["library.proto"],
-    deps = ["@api_common_protos//google/api:client_proto"],
     visibility = ["//visibility:public"],
+    deps = ["@api_common_protos//google/api:client_proto"],
 )
 
 proto_library_with_info(
@@ -15,20 +16,27 @@ proto_library_with_info(
 
 cc_proto_library(
     name = "library_cc_proto",
-    deps = [":library_proto"],
     visibility = ["//visibility:public"],
+    deps = [":library_proto"],
 )
 
-# TODO: Uncomment once cpp GAPIC artifacts compilation errors are fixed
-#cc_gapic_library(
-#    name = "library_cc_gapic",
-#    src = ":library_proto_with_info",
-#    package = "google.example.library.v1",
-#    deps = [
-#        ":library_cc_proto"
-#    ],
-#    visibility = ["//visibility:public"],
-#)
+cc_grpc_library(
+    name = "library_cc_grpc",
+    srcs = [":library_proto"],
+    grpc_only = True,
+    deps = [":library_cc_proto"],
+)
+
+cc_gapic_library(
+    name = "library_cc_gapic",
+    src = ":library_proto_with_info",
+    package = "google.example.library.v1",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":library_cc_grpc",
+        ":library_cc_proto",
+    ],
+)
 
 filegroup(
     name = "library_service_baseline",

--- a/generator/testdata/BUILD.bazel
+++ b/generator/testdata/BUILD.bazel
@@ -1,8 +1,16 @@
+load("//rules_gapic/cpp:cc_gapic.bzl", "cc_gapic_srcjar", "cc_gapic_library")
+load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_library_with_info")
+
 proto_library(
     name = "library_proto",
     srcs = ["library.proto"],
     deps = ["@api_common_protos//google/api:client_proto"],
     visibility = ["//visibility:public"],
+)
+
+proto_library_with_info(
+    name = "library_proto_with_info",
+    deps = [":library_proto"],
 )
 
 cc_proto_library(
@@ -11,6 +19,16 @@ cc_proto_library(
     visibility = ["//visibility:public"],
 )
 
+# TODO: Uncomment once cpp GAPIC artifacts compilation errors are fixed
+#cc_gapic_library(
+#    name = "library_cc_gapic",
+#    src = ":library_proto_with_info",
+#    package = "google.example.library.v1",
+#    deps = [
+#        ":library_cc_proto"
+#    ],
+#    visibility = ["//visibility:public"],
+#)
 
 filegroup(
     name = "library_service_baseline",

--- a/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.cc.baseline
@@ -91,9 +91,9 @@ LibraryService::GetBigBook(
   }
 }
 
-constexpr MethodInfo LibraryService::create_book_info;
-constexpr MethodInfo LibraryService::get_book_info;
-constexpr MethodInfo LibraryService::list_books_info;
-constexpr MethodInfo LibraryService::delete_book_info;
-constexpr MethodInfo LibraryService::update_book_info;
-constexpr MethodInfo LibraryService::get_big_book_info;
+constexpr google::gax::MethodInfo LibraryService::create_book_info;
+constexpr google::gax::MethodInfo LibraryService::get_book_info;
+constexpr google::gax::MethodInfo LibraryService::list_books_info;
+constexpr google::gax::MethodInfo LibraryService::delete_book_info;
+constexpr google::gax::MethodInfo LibraryService::update_book_info;
+constexpr google::gax::MethodInfo LibraryService::get_big_book_info;

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -70,22 +70,22 @@ class LibraryService final {
   //       This will eventually be set from annotations.
   static constexpr google::gax::MethodInfo create_book_info = {
       "CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
   static constexpr google::gax::MethodInfo get_book_info = {
       "GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
   static constexpr google::gax::MethodInfo list_books_info = {
       "ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
   static constexpr google::gax::MethodInfo delete_book_info = {
       "DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
   static constexpr google::gax::MethodInfo update_book_info = {
       "UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
   static constexpr google::gax::MethodInfo get_big_book_info = {
       "GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
-      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+      google::gax::MethodInfo::Idempotency::NON_IDEMPOTENT};
 }; // LibraryService
 
 #endif // LibraryService_H_

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -68,12 +68,24 @@ class LibraryService final {
 
   // Note: conservatively assume no methods are idempotent.
   //       This will eventually be set from annotations.
-  static constexpr google::gax::MethodInfo create_book_info = {"CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  static constexpr google::gax::MethodInfo get_book_info = {"GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  static constexpr google::gax::MethodInfo list_books_info = {"ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  static constexpr google::gax::MethodInfo delete_book_info = {"DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  static constexpr google::gax::MethodInfo update_book_info = {"UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
-  static constexpr google::gax::MethodInfo get_big_book_info = {"GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC};
+  static constexpr google::gax::MethodInfo create_book_info = {
+      "CreateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+  static constexpr google::gax::MethodInfo get_book_info = {
+      "GetBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+  static constexpr google::gax::MethodInfo list_books_info = {
+      "ListBooks", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+  static constexpr google::gax::MethodInfo delete_book_info = {
+      "DeleteBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+  static constexpr google::gax::MethodInfo update_book_info = {
+      "UpdateBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
+  static constexpr google::gax::MethodInfo get_big_book_info = {
+      "GetBigBook", google::gax::MethodInfo::RpcType::NORMAL_RPC,
+      google::gax::MethodInfo::Idempotency::IDEMPOTENT};
 }; // LibraryService
 
 #endif // LibraryService_H_

--- a/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service.gapic.h.baseline
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include "library_service_stub.gapic.h"
-#include "LibraryService.pb.h"
+#include "generator/testdata/library.pb.h"
 #include "gax/status_or.h"
 #include "gax/retry_policy.h"
 #include "gax/backoff_policy.h"

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
@@ -4,7 +4,7 @@
 
 #include "library_service_stub.gapic.h"
 #include "gax/call_context.h"
-#include "gax/Status.h"
+#include "gax/status.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/channel.h"
 #include "grpcpp/create_channel.h"

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
@@ -5,8 +5,8 @@
 #include "library_service_stub.gapic.h"
 #include "generator/testdata/library.grpc.pb.h"
 #include "gax/call_context.h"
-#include "gax/status.h"
 #include "gax/retry_loop.h"
+#include "gax/status.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/channel.h"
 #include "grpcpp/create_channel.h"
@@ -139,8 +139,8 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
 class RetryLibraryServiceStub : public LibraryServiceStub {
  public:
   RetryLibraryServiceStub(std::unique_ptr<LibraryServiceStub> stub,
-                         gax::RetryPolicy const& retry_policy,
-                         gax::BackoffPolicy const& backoff_policy) :
+                          google::gax::RetryPolicy const& retry_policy,
+                          google::gax::BackoffPolicy const& backoff_policy) :
             next_stub_(std::move(stub)),
             default_retry_policy_(retry_policy.clone()),
             default_backoff_policy_(backoff_policy.clone()) {}
@@ -149,14 +149,14 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   CreateBook(google::gax::CallContext& context,
              ::google::example::library::v1::CreateBookRequest const& request,
              ::google::example::library::v1::Book* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::CreateBookRequest const& req,
                 ::google::example::library::v1::Book* resp) {
               return this->next_stub_->CreateBook(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::CreateBookRequest,
-                         ::google::example::library::v1::Book,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::CreateBookRequest,
+                                      ::google::example::library::v1::Book,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
@@ -165,14 +165,14 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   GetBook(google::gax::CallContext& context,
              ::google::example::library::v1::GetBookRequest const& request,
              ::google::example::library::v1::Book* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::GetBookRequest const& req,
                 ::google::example::library::v1::Book* resp) {
               return this->next_stub_->GetBook(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::GetBookRequest,
-                         ::google::example::library::v1::Book,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::GetBookRequest,
+                                      ::google::example::library::v1::Book,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
@@ -181,14 +181,14 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   ListBooks(google::gax::CallContext& context,
              ::google::example::library::v1::ListBooksRequest const& request,
              ::google::example::library::v1::ListBooksResponse* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::ListBooksRequest const& req,
                 ::google::example::library::v1::ListBooksResponse* resp) {
               return this->next_stub_->ListBooks(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::ListBooksRequest,
-                         ::google::example::library::v1::ListBooksResponse,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::ListBooksRequest,
+                                      ::google::example::library::v1::ListBooksResponse,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
@@ -197,14 +197,14 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   DeleteBook(google::gax::CallContext& context,
              ::google::example::library::v1::DeleteBookRequest const& request,
              ::google::example::library::v1::Empty* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::DeleteBookRequest const& req,
                 ::google::example::library::v1::Empty* resp) {
               return this->next_stub_->DeleteBook(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::DeleteBookRequest,
-                         ::google::example::library::v1::Empty,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::DeleteBookRequest,
+                                      ::google::example::library::v1::Empty,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
@@ -213,62 +213,14 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   UpdateBook(google::gax::CallContext& context,
              ::google::example::library::v1::UpdateBookRequest const& request,
              ::google::example::library::v1::Book* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::UpdateBookRequest const& req,
                 ::google::example::library::v1::Book* resp) {
               return this->next_stub_->UpdateBook(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::UpdateBookRequest,
-                         ::google::example::library::v1::Book,
-                         decltype(invoke_stub)>(
-        context, request, response, std::move(invoke_stub),
-        clone_retry(context), clone_backoff(context));
-  }
-
-  google::gax::Status
-  StreamShelves(google::gax::CallContext& context,
-             ::google::example::library::v1::StreamShelvesRequest const& request,
-             ::google::example::library::v1::StreamShelvesResponse* response) override {
-    auto invoke_stub = [=this](CallContext& c,
-                ::google::example::library::v1::StreamShelvesRequest const& req,
-                ::google::example::library::v1::StreamShelvesResponse* resp) {
-              return this->next_stub_->StreamShelves(c, req, resp);
-            };
-    return MakeRetryCall<::google::example::library::v1::StreamShelvesRequest,
-                         ::google::example::library::v1::StreamShelvesResponse,
-                         decltype(invoke_stub)>(
-        context, request, response, std::move(invoke_stub),
-        clone_retry(context), clone_backoff(context));
-  }
-
-  google::gax::Status
-  DiscussBook(google::gax::CallContext& context,
-             ::google::example::library::v1::DiscussBookRequest const& request,
-             ::google::example::library::v1::Comment* response) override {
-    auto invoke_stub = [=this](CallContext& c,
-                ::google::example::library::v1::DiscussBookRequest const& req,
-                ::google::example::library::v1::Comment* resp) {
-              return this->next_stub_->DiscussBook(c, req, resp);
-            };
-    return MakeRetryCall<::google::example::library::v1::DiscussBookRequest,
-                         ::google::example::library::v1::Comment,
-                         decltype(invoke_stub)>(
-        context, request, response, std::move(invoke_stub),
-        clone_retry(context), clone_backoff(context));
-  }
-
-  google::gax::Status
-  MonologAboutBook(google::gax::CallContext& context,
-             ::google::example::library::v1::DiscussBookRequest const& request,
-             ::google::example::library::v1::Comment* response) override {
-    auto invoke_stub = [=this](CallContext& c,
-                ::google::example::library::v1::DiscussBookRequest const& req,
-                ::google::example::library::v1::Comment* resp) {
-              return this->next_stub_->MonologAboutBook(c, req, resp);
-            };
-    return MakeRetryCall<::google::example::library::v1::DiscussBookRequest,
-                         ::google::example::library::v1::Comment,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::UpdateBookRequest,
+                                      ::google::example::library::v1::Book,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
@@ -277,36 +229,36 @@ class RetryLibraryServiceStub : public LibraryServiceStub {
   GetBigBook(google::gax::CallContext& context,
              ::google::example::library::v1::GetBookRequest const& request,
              ::google::example::library::v1::Book* response) override {
-    auto invoke_stub = [=this](CallContext& c,
+    auto invoke_stub = [this](google::gax::CallContext& c,
                 ::google::example::library::v1::GetBookRequest const& req,
                 ::google::example::library::v1::Book* resp) {
               return this->next_stub_->GetBigBook(c, req, resp);
             };
-    return MakeRetryCall<::google::example::library::v1::GetBookRequest,
-                         ::google::example::library::v1::Book,
-                         decltype(invoke_stub)>(
+    return google::gax::MakeRetryCall<::google::example::library::v1::GetBookRequest,
+                                      ::google::example::library::v1::Book,
+                                      decltype(invoke_stub)>(
         context, request, response, std::move(invoke_stub),
         clone_retry(context), clone_backoff(context));
   }
 
  private:
-  std::unique_ptr<gax::RetryPolicy>
-  clone_retry(gax::CallContext const &context) const {
+  std::unique_ptr<google::gax::RetryPolicy>
+  clone_retry(google::gax::CallContext const &context) const {
     auto context_retry = context.RetryPolicy();
-    return context_retry ? context_retry
-                         : default_retry_policy_->clone();
+    return context_retry ? std::move(context_retry)
+                         : std::move(default_retry_policy_->clone());
   }
 
-  std::unique_ptr<gax::BackoffPolicy>
-  clone_backoff(gax::CallContext const &context) const {
+  std::unique_ptr<google::gax::BackoffPolicy>
+  clone_backoff(google::gax::CallContext const &context) const {
     auto context_backoff = context.BackoffPolicy();
-    return context_backoff ? context_backoff
-                           : default_backoff_policy_->clone();
+    return context_backoff ? std::move(context_backoff)
+                           : std::move(default_backoff_policy_->clone());
   }
 
   std::unique_ptr<LibraryServiceStub> next_stub_;
-  const std::unique_ptr<gax::RetryPolicy const> default_retry_policy_;
-  const std::unique_ptr<gax::BackoffPolicy const>  default_backoff_policy_;
+  const std::unique_ptr<google::gax::RetryPolicy const> default_retry_policy_;
+  const std::unique_ptr<google::gax::BackoffPolicy const>  default_backoff_policy_;
 };  // RetryLibraryServiceStub
 }  // namespace
 
@@ -325,9 +277,11 @@ CreateLibraryServiceStub(std::shared_ptr<grpc::ChannelCredentials> creds) {
   using ms = std::chrono::milliseconds;
   // Note: these retry and backoff times are dummy stand ins.
   // More appopriate default values will be chosen later.
+  google::gax::LimitedDurationRetryPolicy<> retry_policy(ms(500), ms(500));
+  google::gax::ExponentialBackoffPolicy backoff_policy(ms(20), ms(100));
   return std::unique_ptr<LibraryServiceStub>(new RetryLibraryServiceStub(
                        std::move(default_stub),
-                       gax::LimitedDurationRetryPolicy(ms(500)),
-                       gax::ExponentialBackoffPolicy(ms(20), ms(100))));
+                       retry_policy,
+                       backoff_policy));
 }
 

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.cc.baseline
@@ -3,6 +3,7 @@
 // source: generator/testdata/library.proto
 
 #include "library_service_stub.gapic.h"
+#include "generator/testdata/library.grpc.pb.h"
 #include "gax/call_context.h"
 #include "gax/status.h"
 #include "grpcpp/client_context.h"
@@ -68,7 +69,7 @@ LibraryServiceStub::~LibraryServiceStub() {}
 namespace {
 class DefaultLibraryServiceStub : public LibraryServiceStub {
  public:
-  DefaultLibraryServiceStub(std::unique_ptr<LibraryService::StubInterface> grpc_stub)
+  DefaultLibraryServiceStub(std::unique_ptr<::google::example::library::v1::LibraryService::StubInterface> grpc_stub)
     : grpc_stub_(std::move(grpc_stub)) {}
 
   DefaultLibraryServiceStub(DefaultLibraryServiceStub const&) = delete;
@@ -79,7 +80,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::CreateBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->CreateBook(&grpc_ctx, request, response));
   }
 
@@ -88,7 +89,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->GetBook(&grpc_ctx, request, response));
   }
 
@@ -97,7 +98,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::ListBooksRequest const& request,
     ::google::example::library::v1::ListBooksResponse* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->ListBooks(&grpc_ctx, request, response));
   }
 
@@ -106,7 +107,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::DeleteBookRequest const& request,
     ::google::example::library::v1::Empty* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->DeleteBook(&grpc_ctx, request, response));
   }
 
@@ -115,7 +116,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::UpdateBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->UpdateBook(&grpc_ctx, request, response));
   }
 
@@ -124,7 +125,7 @@ class DefaultLibraryServiceStub : public LibraryServiceStub {
     ::google::example::library::v1::GetBookRequest const& request,
     ::google::example::library::v1::Book* response) override {
     grpc::ClientContext grpc_ctx;
-    context->PrepareGrpcContext(&grpc_context);
+    context.PrepareGrpcContext(&grpc_ctx);
     return google::gax::GrpcStatusToGaxStatus(grpc_stub_->GetBigBook(&grpc_ctx, request, response));
   }
 

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
@@ -4,7 +4,7 @@
 #ifndef LibraryService_Stub_H_
 #define LibraryService_Stub_H_
 
-#include "LibraryService.pb.h"
+#include "generator/testdata/library.pb.h"
 #include "gax/call_context.h"
 #include "gax/status.h"
 #include "grpcpp/security/credentials.h"

--- a/rules_gapic/cpp/cc_gapic.bzl
+++ b/rules_gapic/cpp/cc_gapic.bzl
@@ -25,8 +25,7 @@ def _cc_gapic_postprocessed_srcjar_impl(ctx):
     script = """
     unzip -q {gapic_zip} -d {output_dir_path}
     # TODO: Call formatter here
-    pushd .
-    cd {output_dir_path}
+    pushd {output_dir_path}
     zip -q -r {output_dir_name}-h.srcjar . -i ./*.gapic.h
     popd
     mv {output_dir_path}/{output_dir_name}-h.srcjar {output_main_h}

--- a/rules_gapic/cpp/cc_gapic.bzl
+++ b/rules_gapic/cpp/cc_gapic.bzl
@@ -1,0 +1,114 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@com_google_api_codegen//rules_gapic:gapic.bzl", "gapic_srcjar", "unzipped_srcjar")
+
+def _cc_gapic_postprocessed_srcjar_impl(ctx):
+    gapic_zip = ctx.file.gapic_zip
+    output_main = ctx.outputs.main
+    output_main_h = ctx.outputs.main_h
+
+    output_dir_name = ctx.label.name
+    output_dir_path = "%s/%s" % (output_main.dirname, output_dir_name)
+
+    script = """
+    unzip -q {gapic_zip} -d {output_dir_path}
+    # TODO: Call formatter here
+    pushd .
+    cd {output_dir_path}
+    zip -q -r {output_dir_name}-h.srcjar . -i ./*.gapic.h
+    popd
+    mv {output_dir_path}/{output_dir_name}-h.srcjar {output_main_h}
+    cp {gapic_zip} {output_main}
+    """.format(
+        gapic_zip = gapic_zip.path,
+        output_dir_name = output_dir_name,
+        output_dir_path = output_dir_path,
+        output_main = output_main.path,
+        output_main_h = output_main_h.path,
+    )
+
+    ctx.actions.run_shell(
+        inputs = [gapic_zip],
+        command = script,
+        outputs = [output_main, output_main_h],
+    )
+
+_cc_gapic_postprocessed_srcjar = rule(
+    _cc_gapic_postprocessed_srcjar_impl,
+    attrs = {
+        "gapic_zip": attr.label(mandatory = True, allow_single_file = True),
+    },
+    outputs = {
+        "main": "%{name}.srcjar",
+        "main_h": "%{name}-h.srcjar",
+    },
+)
+
+def cc_gapic_srcjar(name, src, package, visibility = None):
+    raw_srcjar_name = "%s_raw" % name
+
+    gapic_srcjar(
+        name = raw_srcjar_name,
+        src = src,
+        package = package,
+        output_suffix = ".zip",
+        visibility = visibility,
+        gapic_generator = Label("//generator:protoc-gen-cpp_gapic"),
+    )
+
+    _cc_gapic_postprocessed_srcjar(
+        name = name,
+        gapic_zip = ":%s" % raw_srcjar_name,
+        visibility = visibility,
+    )
+
+def cc_gapic_library(name, src, package, deps = [], visibility = None):
+    srcjar_name = "%s_srcjar" % name
+
+    cc_gapic_srcjar(
+        name = srcjar_name,
+        src = src,
+        package = package,
+        visibility = visibility,
+    )
+
+    actual_deps = deps + [
+        "@com_google_gapic_generator_cpp//gax:gax",
+    ]
+
+    main_file = ":%s.srcjar" % srcjar_name
+    main_dir = "%s_main" % srcjar_name
+
+    unzipped_srcjar(
+        name = main_dir,
+        srcjar = main_file,
+        extension = ".cc",
+    )
+
+    main_h_file = ":%s-h.srcjar" % srcjar_name
+    main_h_dir = "%s_h_main" % srcjar_name
+
+    unzipped_srcjar(
+        name = main_h_dir,
+        srcjar = main_h_file,
+        extension = ".h",
+    )
+
+    native.cc_library(
+        name = name,
+        srcs = [":%s" % main_dir],
+        deps = actual_deps,
+        hdrs = [":%s" % main_h_dir],
+    )


### PR DESCRIPTION
Also fix bugs in the generator output (to make it compilable).

This PR depends on https://github.com/googleapis/gapic-generator/pull/2743.

This PR also depends on cc_grpc_library change in grpc/grpc repository.

