### PR TITLE
Broad, shallow cleanup

### DIFF
--- a/gax/backoff_policy.cc
+++ b/gax/backoff_policy.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gax/backoff_policy.h"
 #include <algorithm>
 #include <chrono>
 #include <memory>
 #include <random>
-
-#include "backoff_policy.h"
 
 namespace google {
 namespace gax {

--- a/gax/backoff_policy.h
+++ b/gax/backoff_policy.h
@@ -15,11 +15,10 @@
 #ifndef GAPIC_GENERATOR_CPP_GAX_BACKOFF_POLICY_H_
 #define GAPIC_GENERATOR_CPP_GAX_BACKOFF_POLICY_H_
 
+#include "gax/internal/gtest_prod.h"
 #include <chrono>
 #include <memory>
 #include <random>
-
-#include "internal/gtest_prod.h"
 
 namespace google {
 namespace gax {

--- a/gax/backoff_policy_test.cc
+++ b/gax/backoff_policy_test.cc
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gax/backoff_policy.h"
+#include <gtest/gtest.h>
 #include <chrono>
 #include <memory>
 #include <random>
-
-#include <gtest/gtest.h>
-
-#include "backoff_policy.h"
 
 namespace google {
 namespace gax {

--- a/gax/call_context.cc
+++ b/gax/call_context.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "call_context.h"
-
+#include "gax/call_context.h"
 #include <chrono>
 
 namespace google {
@@ -43,6 +42,11 @@ void CallContext::AddMetadata(std::string key, std::string val) {
   metadata_.emplace(std::move(key), std::move(val));
 }
 
+std::multimap<std::string, std::string const> const& CallContext::Metadata()
+    const {
+  return metadata_;
+}
+
 MethodInfo CallContext::Info() const { return method_info_; }
 
 std::unique_ptr<gax::RetryPolicy> CallContext::RetryPolicy() const {
@@ -64,5 +68,6 @@ void CallContext::SetBackoffPolicy(gax::BackoffPolicy const& backoff_policy) {
 std::chrono::system_clock::time_point CallContext::Deadline() const {
   return deadline_;
 }
-}
-}
+
+}  // namespace gax
+}  // namespace google

--- a/gax/call_context.h
+++ b/gax/call_context.h
@@ -16,10 +16,8 @@
 #define GAPIC_GENERATOR_CPP_GAX_CALL_CONTEXT_H_
 
 #include "grpcpp/client_context.h"
-#include "internal/gtest_prod.h"
 #include "gax/backoff_policy.h"
 #include "gax/retry_policy.h"
-
 #include <chrono>
 #include <functional>
 #include <map>
@@ -162,6 +160,8 @@ class CallContext {
    */
   void AddMetadata(std::string key, std::string val);
 
+  std::multimap<std::string, std::string const> const& Metadata() const;
+
   /**
    * @brief Set a deadline for the rpc.
    */
@@ -177,28 +177,12 @@ class CallContext {
    */
   MethodInfo Info() const;
 
-  /**
-   * Setter for call-specific retry policy.
-   */
   void SetRetryPolicy(gax::RetryPolicy const& retry_policy);
-
-  /**
-   * Getter for retry policy.
-   */
   std::unique_ptr<gax::RetryPolicy> RetryPolicy() const;
-
-  /**
-   * Getter for backoff policy.
-   */
+  void SetBackoffPolicy(gax::BackoffPolicy const& backoff_policy);
   std::unique_ptr<gax::BackoffPolicy> BackoffPolicy() const;
 
-  /**
-   * Setter for call-specific backoff policy.
-   */
-  void SetBackoffPolicy(gax::BackoffPolicy const& backoff_policy);
-
  private:
-  FRIEND_TEST(CallContext, Basic);
   std::chrono::system_clock::time_point deadline_;
   std::unique_ptr<gax::RetryPolicy const> retry_policy_;
   std::unique_ptr<gax::BackoffPolicy const> backoff_policy_;
@@ -206,7 +190,8 @@ class CallContext {
   std::multimap<std::string, std::string const> metadata_;
   MethodInfo const method_info_;
 };
-}
-}
+
+}  // namespace gax
+}  // namespace google
 
 #endif  // GAPIC_GENERATOR_CPP_GAX_CALL_CONTEXT_H_

--- a/gax/call_context_test.cc
+++ b/gax/call_context_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "gax/call_context.h"
-#include "googletest/include/gtest/gtest.h"
 #include "gax/backoff_policy.h"
 #include "gax/retry_policy.h"
+#include <gtest/gtest.h>
 #include <chrono>
 #include <set>
 #include <string>

--- a/gax/call_context_test.cc
+++ b/gax/call_context_test.cc
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "call_context.h"
-#include "backoff_policy.h"
+#include "gax/call_context.h"
 #include "googletest/include/gtest/gtest.h"
-#include "retry_policy.h"
-
+#include "gax/backoff_policy.h"
+#include "gax/retry_policy.h"
 #include <chrono>
 #include <set>
 #include <string>
@@ -47,15 +46,15 @@ TEST(CallContext, Basic) {
   EXPECT_EQ(ctx.Deadline(), now);
 
   ctx.AddMetadata("testKey", "testVal");
-  auto iter = ctx.metadata_.find("testKey");
-  EXPECT_NE(iter, ctx.metadata_.end());
+  auto iter = ctx.Metadata().find("testKey");
+  EXPECT_NE(iter, ctx.Metadata().end());
   EXPECT_EQ(iter->second, "testVal");
 
   std::set<std::string> const vals = {"testVal", "testVal2"};
   std::set<std::string> tmp;
   ctx.AddMetadata("testKey", "testVal2");
-  EXPECT_EQ(ctx.metadata_.count("testKey"), std::size_t(2));
-  auto range = ctx.metadata_.equal_range("testKey");
+  EXPECT_EQ(ctx.Metadata().count("testKey"), std::size_t(2));
+  auto range = ctx.Metadata().equal_range("testKey");
   for (auto i = range.first; i != range.second; ++i) {
     tmp.insert(i->second);
   }

--- a/gax/operation_test.cc
+++ b/gax/operation_test.cc
@@ -199,7 +199,7 @@ TEST(Operation, Result) {
   lro.set_name("test");
   TestOperation op(std::move(lro));
   auto incomplete_res = op.Result();
-  EXPECT_EQ(bool(incomplete_res), false);
+  EXPECT_EQ(static_cast<bool>(incomplete_res), false);
   EXPECT_EQ(incomplete_res.status(),
             gax::Status(gax::StatusCode::kUnknown,
                         "operation has not completed=test"));
@@ -209,7 +209,7 @@ TEST(Operation, Result) {
   client.Update(op);
   EXPECT_TRUE(op.Done());
   auto error_res = op.Result();
-  EXPECT_EQ(bool(error_res), false);
+  EXPECT_EQ(static_cast<bool>(error_res), false);
   EXPECT_EQ(error_res.status(), gax::Status(gax::StatusCode::kNotFound,
                                             "This is an error message"));
 
@@ -218,7 +218,7 @@ TEST(Operation, Result) {
   stub->set_error = false;
   client.Update(op);
   auto success_res = op.Result();
-  EXPECT_EQ(bool(success_res), true);
+  EXPECT_EQ(static_cast<bool>(success_res), true);
   EXPECT_EQ((*success_res).name(), "dummy-response");
 
   lro.set_name("test");
@@ -226,7 +226,7 @@ TEST(Operation, Result) {
   op = TestOperation(std::move(lro));
   client.Update(op);
   auto bad_result = op.Result();
-  EXPECT_EQ(bool(bad_result), false);
+  EXPECT_EQ(static_cast<bool>(bad_result), false);
   EXPECT_EQ(bad_result.status(),
             gax::Status(gax::StatusCode::kUnknown,
                         "invalid result in operation=test-response"));

--- a/gax/operation_test.cc
+++ b/gax/operation_test.cc
@@ -14,10 +14,10 @@
 
 #include "gax/operation.h"
 #include "google/longrunning/operations.pb.h"
-#include "googletest/include/gtest/gtest.h"
 #include "gax/operations_client.h"
 #include "gax/operations_stub.h"
 #include "gax/status.h"
+#include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/gax/operations_stub_test.cc
+++ b/gax/operations_stub_test.cc
@@ -14,10 +14,10 @@
 
 #include "gax/operations_stub.h"
 #include "google/longrunning/operations.pb.h"
-#include "googletest/include/gtest/gtest.h"
 #include "gax/call_context.h"
 #include "gax/operations_client.h"
 #include "gax/status.h"
+#include <gtest/gtest.h>
 
 namespace {
 

--- a/gax/retry_loop_test.cc
+++ b/gax/retry_loop_test.cc
@@ -14,10 +14,10 @@
 
 #include "gax/retry_loop.h"
 #include "google/longrunning/operations.pb.h"
-#include "googletest/include/gtest/gtest.h"
 #include "gax/backoff_policy.h"
 #include "gax/call_context.h"
 #include "gax/retry_policy.h"
+#include <gtest/gtest.h>
 #include <chrono>
 
 namespace {

--- a/gax/retry_policy.h
+++ b/gax/retry_policy.h
@@ -15,10 +15,9 @@
 #ifndef GAPIC_GENERATOR_CPP_GAX_RETRY_POLICY_H_
 #define GAPIC_GENERATOR_CPP_GAX_RETRY_POLICY_H_
 
+#include "gax/status.h"
 #include <chrono>
 #include <memory>
-
-#include "status.h"
 
 namespace google {
 namespace gax {

--- a/gax/retry_policy_test.cc
+++ b/gax/retry_policy_test.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gax/retry_policy.h"
+#include "gax/status.h"
+#include <gtest/gtest.h>
 #include <chrono>
 #include <memory>
-
-#include "retry_policy.h"
-#include "status.h"
-#include <gtest/gtest.h>
 
 namespace {
 using namespace ::google;

--- a/gax/status.cc
+++ b/gax/status.cc
@@ -15,7 +15,7 @@
 #include <ostream>
 #include <string>
 
-#include "status.h"
+#include "gax/status.h"
 
 namespace google {
 namespace gax {

--- a/gax/status.h
+++ b/gax/status.h
@@ -16,7 +16,6 @@
 #define GAPIC_GENERATOR_CPP_GAX_STATUS_H_
 
 #include "grpcpp/impl/codegen/status.h"
-
 #include <ostream>
 #include <string>
 

--- a/gax/status_or.h
+++ b/gax/status_or.h
@@ -15,11 +15,10 @@
 #ifndef GAPIC_GENERATOR_CPP_GAX_STATUS_OR_H_
 #define GAPIC_GENERATOR_CPP_GAX_STATUS_OR_H_
 
+#include "gax/status.h"
 #include <cstdlib>
 #include <iostream>
 #include <memory>
-
-#include "status.h"
 
 namespace google {
 namespace gax {

--- a/gax/status_or_test.cc
+++ b/gax/status_or_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "status_or.h"
-#include "status.h"
+#include "gax/status_or.h"
+#include "gax/status.h"
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/gax/status_test.cc
+++ b/gax/status_test.cc
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "status.h"
+#include "gax/status.h"
 #include <gtest/gtest.h>
-
 #include <sstream>
 #include <string>
 

--- a/generator/gapic_generator.h
+++ b/generator/gapic_generator.h
@@ -14,10 +14,9 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_GAPIC_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_GAPIC_GENERATOR_H_
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
+#include <string>
 
 namespace google {
 namespace api {

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
 #include <fstream>
+#include <gapic_generator.h>
+#include <iostream>
 #include <memory>
+#include <standalone.h>
 #include <string>
 #include <vector>
-
-#include <iostream>
-
-#include <gtest/gtest.h>
-
-#include <gapic_generator.h>
-#include <standalone.h>
 
 namespace google {
 namespace api {

--- a/generator/internal/client_cc_generator.cc
+++ b/generator/internal/client_cc_generator.cc
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <string>
 
-#include "gapic_utils.h"
-#include "printer.h"
 #include "generator/internal/client_cc_generator.h"
 #include "generator/internal/data_model.h"
+#include "generator/internal/gapic_utils.h"
+#include "generator/internal/printer.h"
 #include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
@@ -100,7 +100,7 @@ bool GenerateClientCC(pb::ServiceDescriptor const* service,
   }
 
   return true;
-}  // namespace internal
+}
 
 }  // namespace internal
 }  // namespace codegen

--- a/generator/internal/client_cc_generator.h
+++ b/generator/internal/client_cc_generator.h
@@ -14,12 +14,11 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_CLIENT_CC_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_CLIENT_CC_GENERATOR_H_
 
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <memory>
 #include <sstream>
 #include <string>
-
-#include "printer.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/client_header_generator.cc
+++ b/generator/internal/client_header_generator.cc
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "generator/internal/client_header_generator.h"
+#include "generator/internal/data_model.h"
+#include "generator/internal/gapic_utils.h"
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <memory>
 #include <sstream>
 #include <string>
-
-#include "gapic_utils.h"
-#include "printer.h"
-#include "generator/internal/client_header_generator.h"
-#include "generator/internal/data_model.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/client_header_generator.h
+++ b/generator/internal/client_header_generator.h
@@ -14,12 +14,11 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_CLIENT_HEADER_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_CLIENT_HEADER_GENERATOR_H_
 
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <memory>
 #include <sstream>
 #include <string>
-
-#include "printer.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/data_model.h
+++ b/generator/internal/data_model.h
@@ -14,22 +14,20 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_DATA_MODEL_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_DATA_MODEL_H_
 
-#include <algorithm>
-#include <cctype>
-#include <functional>
-#include <string>
-
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "google/api/client.pb.h"
+#include "generator/internal/gapic_utils.h"
+#include "generator/internal/printer.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
-
-#include "gapic_utils.h"
-#include "printer.h"
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <string>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/gapic_utils.cc
+++ b/generator/internal/gapic_utils.cc
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "generator/internal/gapic_utils.h"
 #include <string>
-
-#include "gapic_utils.h"
 
 namespace google {
 namespace api {

--- a/generator/internal/gapic_utils.h
+++ b/generator/internal/gapic_utils.h
@@ -14,16 +14,14 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_GAPIC_UTILS_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_GAPIC_UTILS_H_
 
-#include <algorithm>
-#include <cctype>
-#include <string>
-
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
-
 #include <google/protobuf/descriptor.h>
+#include <algorithm>
+#include <cctype>
+#include <string>
 
 namespace google {
 namespace api {

--- a/generator/internal/stub_cc_generator.cc
+++ b/generator/internal/stub_cc_generator.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "stub_cc_generator.h"
-#include "gapic_utils.h"
-#include "printer.h"
+#include "generator/internal/stub_cc_generator.h"
 #include "generator/internal/data_model.h"
+#include "generator/internal/gapic_utils.h"
+#include "generator/internal/printer.h"
 #include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;

--- a/generator/internal/stub_cc_generator.h
+++ b/generator/internal/stub_cc_generator.h
@@ -15,11 +15,10 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_STUB_CC_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_STUB_CC_GENERATOR_H_
 
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <map>
 #include <string>
-
-#include "printer.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "generator/internal/stub_header_generator.h"
+#include "generator/internal/data_model.h"
+#include "generator/internal/gapic_utils.h"
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <map>
 #include <string>
-
-#include "data_model.h"
-#include "gapic_utils.h"
-#include "printer.h"
-#include "stub_header_generator.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 
@@ -94,6 +93,7 @@ bool GenerateClientStubHeader(pb::ServiceDescriptor const* service,
 
   return true;
 }
+
 }  // namespace internal
 }  // namespace codegen
 }  // namespace api

--- a/generator/internal/stub_header_generator.h
+++ b/generator/internal/stub_header_generator.h
@@ -15,11 +15,10 @@
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_STUB_HEADER_GENERATOR_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_INTERNAL_STUB_HEADER_GENERATOR_H_
 
+#include "generator/internal/printer.h"
+#include <google/protobuf/descriptor.h>
 #include <map>
 #include <string>
-
-#include "printer.h"
-#include <google/protobuf/descriptor.h>
 
 namespace pb = google::protobuf;
 

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -1,9 +1,8 @@
-#include <fstream>
-#include <standalone.h>
-
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/stubs/io_win32.h>
+#include <fstream>
 #include <gapic_generator.h>
+#include <standalone.h>
 
 #include "absl/strings/str_split.h"
 
@@ -152,7 +151,7 @@ int StandaloneMain(std::vector<std::string> const& descriptors,
                                      package_arg.c_str(), output_arg.c_str()};
 
   return StandaloneMain((int)c_args.size(), c_args.data(), generator);
-};
+}
 
 }  // namespace codegen
 }  // namespace api

--- a/generator/standalone.cc
+++ b/generator/standalone.cc
@@ -1,10 +1,23 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "generator/standalone.h"
+#include "absl/strings/str_split.h"
+#include "generator/gapic_generator.h"
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/stubs/io_win32.h>
 #include <fstream>
-#include <gapic_generator.h>
-#include <standalone.h>
-
-#include "absl/strings/str_split.h"
 
 namespace google {
 namespace api {

--- a/generator/standalone.h
+++ b/generator/standalone.h
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_
 #define GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_
 
@@ -18,4 +32,5 @@ int StandaloneMain(const std::vector<std::string>& descriptors,
 }  // namespace codegen
 }  // namespace api
 }  // namespace google
+
 #endif  // GAPIC_GENERATOR_CPP_GENERATOR_STANDALONE_H_


### PR DESCRIPTION
Unify include style and ordering of headers
Add gax and gax/include to include paths where appropriate
Add missing namespace close comments
Remove FRIEND_TEST macro from CallContext