### PR TITLE
Add test and impl for setting per-rpc deadlines in retry loop

### DIFF
--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -62,12 +62,20 @@ gax_unit_tests = [
     "status_or_test.cc",
 ]
 
+cc_library(
+    name = "gax_testlib",
+    srcs = [],
+    hdrs = [ "internal/test_clock.h"],
+    deps = [],
+)
+
 [cc_test(
     name = "gax_" + test.replace(".cc", ""),
     size = "small",
     srcs = [test],
     deps = [
         "//gax",
+        ":gax_testlib",
         "@gtest//:gtest_main",
     ],
 ) for test in gax_unit_tests]

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -65,7 +65,7 @@ gax_unit_tests = [
 cc_library(
     name = "gax_testlib",
     srcs = [],
-    hdrs = [ "internal/test_clock.h"],
+    hdrs = ["internal/test_clock.h"],
     deps = [],
 )
 

--- a/gax/call_context_test.cc
+++ b/gax/call_context_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gax/call_context.h"
+#include "grpcpp/client_context.h"
 #include "gax/backoff_policy.h"
 #include "gax/retry_policy.h"
 #include <gtest/gtest.h>
@@ -85,7 +86,8 @@ TEST(CallContext, CopyAndMove) {
   EXPECT_FALSE(no_policy_move.RetryPolicy());
   EXPECT_FALSE(no_policy_move.BackoffPolicy());
 
-  base.SetRetryPolicy(gax::LimitedErrorCountRetryPolicy(10));
+  base.SetRetryPolicy(
+      gax::LimitedErrorCountRetryPolicy<>(10, std::chrono::milliseconds(2)));
   base.SetBackoffPolicy(gax::ExponentialBackoffPolicy(
       std::chrono::milliseconds(1), std::chrono::milliseconds(10)));
   gax::CallContext policy_copy(base);

--- a/gax/internal/test_clock.h
+++ b/gax/internal/test_clock.h
@@ -1,0 +1,45 @@
+// Copyright 2019 Google Inc.  All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GAPIC_GENERATOR_CPP_GAX_INTERNAL_TEST_CLOCK_H_
+#define GAPIC_GENERATOR_CPP_GAX_INTERNAL_TEST_CLOCK_H_
+
+#include <chrono>
+
+namespace google {
+namespace gax {
+namespace internal {
+
+// Each test that uses TestClock defines its own static now_point in the
+// google::gax::internal namespace.
+// The 'now' method and now_point must be static because
+// std::chrono::system_clock::now is static. The alternative would be to store a
+// clock instance in whatever types need a clock, which is unnecessarily
+// heavyweight just to support testing.
+extern std::chrono::time_point<std::chrono::system_clock> now_point;
+
+class TestClock {
+ public:
+  static inline std::chrono::time_point<std::chrono::system_clock> now() {
+    return now_point;
+  }
+
+  static std::chrono::time_point<std::chrono::system_clock> now_point;
+};
+
+}  // namespace internal
+}  // namespace gax
+}  // namespace google
+
+#endif  // GAPIC_GENERATOR_CPP_GAX_INTERNAL_TEST_CLOCK_H_

--- a/gax/retry_loop.h
+++ b/gax/retry_loop.h
@@ -39,6 +39,7 @@ gax::Status MakeRetryCall(gax::CallContext& context, RequestT const& request,
     // The next layer stub may add metadata, so create a
     // fresh call context each time through the loop.
     gax::CallContext context_copy(context);
+    context_copy.SetDeadline(retry_policy->OperationDeadline());
     gax::Status status = next_stub(context_copy, request, response);
     if (status.IsOk() || !retry_policy->OnFailure(status)) {
       return status;

--- a/gax/retry_policy_test.cc
+++ b/gax/retry_policy_test.cc
@@ -17,6 +17,7 @@
 #include "gax/status.h"
 #include <gtest/gtest.h>
 #include <chrono>
+#include <iostream>
 #include <memory>
 
 namespace {
@@ -176,6 +177,18 @@ TEST(LimitedDurationRetryPolicy, OperationDeadline) {
   auto clone = tested.clone();
   now_point += std::chrono::milliseconds(50);
   EXPECT_EQ(tested.OperationDeadline(), clone->OperationDeadline());
+}
+
+TEST(LimitedDurationRetryPolicy, OperationDeadlineCap) {
+  std::chrono::system_clock::time_point now_point;
+  gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
+      std::chrono::milliseconds(500), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
+
+  // Don't exceed the overarching timeout
+  now_point += std::chrono::milliseconds(490);
+  EXPECT_EQ(tested.OperationDeadline(),
+            now_point + std::chrono::milliseconds(10));
 }
 
 }  // namespace

--- a/gax/retry_policy_test.cc
+++ b/gax/retry_policy_test.cc
@@ -19,15 +19,6 @@
 #include <chrono>
 #include <memory>
 
-namespace google {
-namespace gax {
-namespace internal {
-std::chrono::time_point<std::chrono::system_clock>
-    google::gax::internal::TestClock::now_point;
-}  // namespace internal
-}  // namespace gax
-}  // namespace google
-
 namespace {
 using namespace ::google;
 
@@ -93,44 +84,51 @@ TEST(LimitedErrorCountRetryPolicy, Clone) {
 }
 
 TEST(LimitedErrorCountRetryPolicy, OperationDeadline) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedErrorCountRetryPolicy<gax::internal::TestClock> tested(
-      3, std::chrono::milliseconds(30));
+      3, std::chrono::milliseconds(30), gax::internal::TestClock(now_point));
 
   EXPECT_EQ(tested.OperationDeadline(),
-            gax::internal::TestClock::now() + std::chrono::milliseconds(30));
+            now_point + std::chrono::milliseconds(30));
 
   auto clone = tested.clone();
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(50);
+  now_point += std::chrono::milliseconds(50);
   EXPECT_EQ(tested.OperationDeadline(), clone->OperationDeadline());
 }
 
 TEST(LimitedDurationRetryPolicy, Basic) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(5), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(5), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
   gax::Status s;
   EXPECT_TRUE(tested.OnFailure(s));
 
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(2);
+  now_point += std::chrono::milliseconds(2);
   EXPECT_TRUE(tested.OnFailure(s));
 
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(10);
+  now_point += std::chrono::milliseconds(10);
   EXPECT_FALSE(tested.OnFailure(s));
 }
 
 TEST(LimitedDurationRetryPolicy, PermanentFailureCheck) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(5), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(5), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
   gax::Status s{gax::StatusCode::kCancelled, ""};
 
   EXPECT_FALSE(tested.OnFailure(s));
 }
 
 TEST(LimitedDurationRetryPolicy, CopyConstruct) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(5), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(5), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
   gax::Status s;
 
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(10);
+  now_point += std::chrono::milliseconds(10);
   EXPECT_FALSE(tested.OnFailure(s));
 
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> copy(tested);
@@ -138,11 +136,13 @@ TEST(LimitedDurationRetryPolicy, CopyConstruct) {
 }
 
 TEST(LimitedDurationRetryPolicy, MoveConstruct) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(5), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(5), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
   gax::Status s;
 
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(10);
+  now_point += std::chrono::milliseconds(10);
   EXPECT_FALSE(tested.OnFailure(s));
 
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> copy(
@@ -151,11 +151,13 @@ TEST(LimitedDurationRetryPolicy, MoveConstruct) {
 }
 
 TEST(LimitedDurationRetryPolicy, Clone) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(5), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(5), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
   gax::Status s;
 
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(10);
+  now_point += std::chrono::milliseconds(10);
   EXPECT_FALSE(tested.OnFailure(s));
 
   std::unique_ptr<gax::RetryPolicy> clone = tested.clone();
@@ -163,14 +165,16 @@ TEST(LimitedDurationRetryPolicy, Clone) {
 }
 
 TEST(LimitedDurationRetryPolicy, OperationDeadline) {
+  std::chrono::system_clock::time_point now_point;
   gax::LimitedDurationRetryPolicy<gax::internal::TestClock> tested(
-      std::chrono::milliseconds(500), std::chrono::milliseconds(30));
+      std::chrono::milliseconds(500), std::chrono::milliseconds(30),
+      gax::internal::TestClock(now_point));
 
   EXPECT_EQ(tested.OperationDeadline(),
-            gax::internal::TestClock::now() + std::chrono::milliseconds(30));
+            now_point + std::chrono::milliseconds(30));
 
   auto clone = tested.clone();
-  gax::internal::TestClock::now_point += std::chrono::milliseconds(50);
+  now_point += std::chrono::milliseconds(50);
   EXPECT_EQ(tested.OperationDeadline(), clone->OperationDeadline());
 }
 

--- a/generator/internal/stub_header_generator.cc
+++ b/generator/internal/stub_header_generator.cc
@@ -80,7 +80,7 @@ bool GenerateClientStubHeader(pb::ServiceDescriptor const* service,
   p->Print(vars,
            "  virtual ~$stub_class_name$() = 0;\n"
            "\n"
-           "}; // $stub_class_name$\n"
+           "};  // $stub_class_name$\n"
            "\n"
            "std::unique_ptr<$stub_class_name$>\n"
            "Create$stub_class_name$();\n"
@@ -89,7 +89,7 @@ bool GenerateClientStubHeader(pb::ServiceDescriptor const* service,
            "Create$stub_class_name$(std::shared_ptr<grpc::ChannelCredentials> "
            "creds);\n"
            "\n"
-           "#endif // $stub_header_include_guard_const$\n");
+           "#endif  // $stub_header_include_guard_const$\n");
 
   return true;
 }

--- a/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
+++ b/generator/testdata/google/example/library/v1/library_service_stub.gapic.h.baseline
@@ -38,7 +38,7 @@ class LibraryServiceStub {
 
   virtual ~LibraryServiceStub() = 0;
 
-}; // LibraryServiceStub
+};  // LibraryServiceStub
 
 std::unique_ptr<LibraryServiceStub>
 CreateLibraryServiceStub();
@@ -46,4 +46,4 @@ CreateLibraryServiceStub();
 std::unique_ptr<LibraryServiceStub>
 CreateLibraryServiceStub(std::shared_ptr<grpc::ChannelCredentials> creds);
 
-#endif // LibraryService_Stub_H_
+#endif  // LibraryService_Stub_H_


### PR DESCRIPTION
gax::CallContext uses RetryPolicy, so a RetryPolicy::Setup method that
takes a CallContext leads to circular dependencies.

The alternative chosen here is to divide the responsibility:
RetryPolicy _calculates_ the next rpc deadline, and the retry loop
_sets_ the deadline for the CallContext used in the next attempt.