### PR TITLE
Fix *_gapic_library linking problem

### DIFF
--- a/rules_gapic/cpp/cc_gapic.bzl
+++ b/rules_gapic/cpp/cc_gapic.bzl
@@ -117,8 +117,8 @@ def cc_gapic_library(name, src, package, deps = [], **kwargs):
         hdrs = [":%s" % main_h_dir],
         includes = [main_h_dir],
         # cc_library generates an empty .so file, making dynamic linking
-        # impossible. This is probably caused by us using directory
-        # (not exact files) as srcs input (not files).
+        # impossible. This may be caused by us using a directory (instead of
+        # exact files) as srcs input.
         linkstatic = True,
         **kwargs
     )

--- a/rules_gapic/cpp/cc_gapic.bzl
+++ b/rules_gapic/cpp/cc_gapic.bzl
@@ -116,5 +116,9 @@ def cc_gapic_library(name, src, package, deps = [], **kwargs):
         deps = actual_deps,
         hdrs = [":%s" % main_h_dir],
         includes = [main_h_dir],
+        # cc_library generates an empty .so file, making dynamic linking
+        # impossible. This is probably caused by us using directory
+        # (not exact files) as srcs input (not files).
+        linkstatic = True,
         **kwargs
     )


### PR DESCRIPTION
This is done by enforcing static linking. `cc_library` generates empty `.so` file (without corresponding symbols in it). This could be caused by us using directory as input instead of static files. In general could be a bug in Bazel's native `cc_library` rule implementation.