### PR TITLE
Cleanup integration with googleapis repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,61 +25,30 @@ load(
 )
 
 com_google_gapic_generator_cpp_gax_repositories()
+
+load(
+    "@com_google_googleapis//:repository_rules.bzl",
+    "switched_rules_by_language",
+)
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    gapic = True,
+    grpc = True,
+)
+
 com_google_gapic_generator_cpp_repositories()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-# WARNING: The java and go segments below are a hack to get
-# C++ operations proto types to build.
-# Tracked by https://github.com/googleapis/gapic-generator-cpp/issues/35
-
-##############################################################################
-# Java
-##############################################################################
-
 #
-# gapic-generator
+# gapic-generator (contains common definitions for gapic rules)
 #
 http_archive(
     name = "com_google_api_codegen",
-    urls = ["https://github.com/googleapis/gapic-generator/archive/025ebdbb3d14609be938900a538418858b0ecfb7.zip"],
     strip_prefix = "gapic-generator-025ebdbb3d14609be938900a538418858b0ecfb7",
+    urls = ["https://github.com/googleapis/gapic-generator/archive/025ebdbb3d14609be938900a538418858b0ecfb7.zip"],
 )
-
-#
-# java_gapic artifacts runtime dependencies (gax-java)
-#
-load("@com_google_api_codegen//rules_gapic/java:java_gapic_repositories.bzl", "java_gapic_repositories")
-
-java_gapic_repositories()
-
-load("@com_google_api_gax_java//:repository_rules.bzl", "com_google_api_gax_java_properties")
-
-com_google_api_gax_java_properties(
-    name = "com_google_api_gax_java_properties",
-    file = "@com_google_api_gax_java//:dependencies.properties",
-)
-
-load("@com_google_api_gax_java//:repositories.bzl", "com_google_api_gax_java_repositories")
-
-com_google_api_gax_java_repositories()
-##############################################################################
-# Go
-##############################################################################
-
-#
-# rules_go (support Golang under bazel)
-#
-http_archive(
-    name = "io_bazel_rules_go",
-    strip_prefix = "rules_go-7d17d496a6b32f6a573c6c22e29c58204eddf3d4",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/7d17d496a6b32f6a573c6c22e29c58204eddf3d4.zip"],
-)
-
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,7 +45,8 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
 
 #
-# gapic-generator (contains common definitions for gapic rules)
+# gapic-generator (contains common definitions for gapic rules, see gapic.bzl
+# file in com_google_api_codegen)
 #
 http_archive(
     name = "com_google_api_codegen",

--- a/gax/BUILD.bazel
+++ b/gax/BUILD.bazel
@@ -16,13 +16,6 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-# Note: googleapis doesn't define a cc_proto_library for operations_proto,
-# so declare one here ourselves.
-cc_proto_library(
-    name = "longrunning_cpp_proto",
-    deps = ["@com_google_googleapis//google/longrunning:operations_proto"],
-)
-
 cc_library(
     name = "gax",
     srcs = [
@@ -48,7 +41,7 @@ cc_library(
     ],
     deps = [
         "@com_github_grpc_grpc//:grpc++",
-        ":longrunning_cpp_proto",
+        "@com_google_googleapis//google/longrunning:longrunning_cc_proto",
     ],
 )
 

--- a/gax/repositories.bzl
+++ b/gax/repositories.bzl
@@ -18,8 +18,8 @@ def com_google_gapic_generator_cpp_gax_repositories():
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc",
-        urls = ["https://github.com/grpc/grpc/archive/v1.21.0.tar.gz"],
         strip_prefix = "grpc-1.21.0",
+        urls = ["https://github.com/grpc/grpc/archive/v1.21.0.tar.gz"],
     )
 
     _maybe(

--- a/gax/repositories.bzl
+++ b/gax/repositories.bzl
@@ -18,15 +18,15 @@ def com_google_gapic_generator_cpp_gax_repositories():
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc",
-        strip_prefix = "grpc-cc75d93818410e2b0edd0fa3009a6def9ac403ca",
-        urls = ["https://github.com/grpc/grpc/archive/cc75d93818410e2b0edd0fa3009a6def9ac403ca.tar.gz"],
+        urls = ["https://github.com/grpc/grpc/archive/v1.21.0.tar.gz"],
+        strip_prefix = "grpc-1.21.0",
     )
 
     _maybe(
         http_archive,
         name = "com_google_googleapis",
-        strip_prefix = "googleapis-1a479920eb4f6c2bc4c8d8acd9280720540709e4",
-        urls = ["https://github.com/googleapis/googleapis/archive/1a479920eb4f6c2bc4c8d8acd9280720540709e4.tar.gz"],
+        strip_prefix = "googleapis-c69355435cf6ae824a21f2bba31c69697733d3d2",
+        urls = ["https://github.com/googleapis/googleapis/archive/c69355435cf6ae824a21f2bba31c69697733d3d2.tar.gz"],
     )
 
 def _maybe(repo_rule, name, **kwargs):

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -40,7 +40,7 @@ cc_library(
     deps = [
         "@absl//absl/base",
         "@absl//absl/strings",
-        "@api_common_protos//google/api:client_cc_proto",
+        "@com_google_googleapis//google/api:client_cc_proto",
         "@com_google_protobuf//:protoc_lib",
     ],
 )
@@ -64,7 +64,7 @@ cc_test(
     data = [
         "//generator/testdata:library_proto",
         "//generator/testdata:library_service_baseline",
-        "@api_common_protos//google/api:client_proto",
+        "@com_google_googleapis//google/api:client_proto",
         "@com_google_protobuf//:descriptor_proto",
     ],
     deps = [

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -44,7 +44,8 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
           "com_google_gapic_generator_cpp/generator/testdata/"
           "library_proto-descriptor-set.proto.bin",
       input_dir +
-          "com_google_googleapis/google/api/client_proto-descriptor-set.proto.bin",
+          "com_google_googleapis/google/api/"
+          "client_proto-descriptor-set.proto.bin",
       input_dir +
           "com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"};
   std::string package = "google.example.library.v1";

--- a/generator/gapic_generator_test.cc
+++ b/generator/gapic_generator_test.cc
@@ -44,7 +44,7 @@ TEST(GapicGeneratorBaselineTest, StandaloneTest) {
           "com_google_gapic_generator_cpp/generator/testdata/"
           "library_proto-descriptor-set.proto.bin",
       input_dir +
-          "api_common_protos/google/api/client_proto-descriptor-set.proto.bin",
+          "com_google_googleapis/google/api/client_proto-descriptor-set.proto.bin",
       input_dir +
           "com_google_protobuf/descriptor_proto-descriptor-set.proto.bin"};
   std::string package = "google.example.library.v1";

--- a/generator/testdata/BUILD.bazel
+++ b/generator/testdata/BUILD.bazel
@@ -6,7 +6,7 @@ proto_library(
     name = "library_proto",
     srcs = ["library.proto"],
     visibility = ["//visibility:public"],
-    deps = ["@api_common_protos//google/api:client_proto"],
+    deps = ["@com_google_googleapis//google/api:client_proto"],
 )
 
 proto_library_with_info(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -52,9 +52,9 @@ def com_google_gapic_generator_cpp_repositories():
 
     _maybe(
         http_archive,
-        name = "api_common_protos",
-        strip_prefix = "api-common-protos-87185dfffad4afa5a33a8c153f0e1ea53b4f85dc",
-        urls = ["https://github.com/googleapis/api-common-protos/archive/87185dfffad4afa5a33a8c153f0e1ea53b4f85dc.tar.gz"],
+        name = "com_google_googleapis",
+        strip_prefix = "googleapis-c69355435cf6ae824a21f2bba31c69697733d3d2",
+        urls = ["https://github.com/googleapis/googleapis/archive/c69355435cf6ae824a21f2bba31c69697733d3d2.tar.gz"],
     )
 
     _maybe(


### PR DESCRIPTION
Also replace dependency on `api-common-protos` with `googleapis` (since we already depend on it, otherwise we depend on two copies of same thing).

It looks like `api-common-protos` is not going anywhere (there is no current realistic plan to switch to `api-common-protos` in foreseeable future, and `gapic-generator-cpp` is the only user of that, while `googleapis` remains our source of truth). In case if it changes, we can put `api-common-protos` back easily.