### PR TITLE
Add design and status docs

### DIFF
--- a/docs/GENERATOR.md
+++ b/docs/GENERATOR.md
@@ -1,0 +1,85 @@
+# C++ GAPIC Generator Design Review #
+
+*Authors: michaelbausor@google.com, vam@google.com, dovs@google.com*
+
+Objective
+=========
+
+Describe the design of a C++ client library generator. This document covers the design of the **generator**; the [generated surface](SURFACE.md) and GAX-owned primitives are discussed in other docs.
+
+
+Compatibility
+-------------
+
+We will support the google-cloud-cpp repository as our first and primary customer. Because we intend to support users building and running the
+GAPIC generator themselves (possibly as part of compiling a project that consumes the generated surface), we will aim to support the [*same set*](https://github.com/googleapis/google-cloud-cpp/tree/master#requirements) of compilers, build tools, dependency versions, and platforms with our generator as are supported by google-cloud-cpp (and by our generated code).
+
+The generator will **\*not\* throw exceptions**, making it compatible with code that is compiled without exception support.
+
+Dependencies
+------------
+
+We will attempt to minimize the number of external dependencies taken by the generator. Because the generator will implement the protobuf [*CodeGenerator*](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/code_generator.h#L66) interface, we have a dependency on protobuf. We will also take an \*internal only\* dependency on the [*abseil*](https://abseil.io/) library.
+
+Versioning and Publishing
+-------------------------
+
+The GAPIC generator will follow semantic versioning. Once the generator is declared GA, we are committing to not breaking users of the generator, **and** not making any breaking changes in the generated surface. We will use Github releases to tag and publish generator versions. Initially we will not support any C++ package managers. However, we will facilitate community contributions so that package manager support is possible in future. 
+
+Building the Generator
+----------------------
+
+The generator will be buildable via bazel and cmake, similar to the existing google-cloud-cpp repository. We will use bazel as the source of truth, and generate cmake files from bazel. Example of building using bazel:
+
+```bash
+$ git clone https://github.com/googleapis/gapic-generator-cpp
+$ cd gapic-generator-cpp
+$ bazel build ...
+$ bazel test ...
+```
+
+Consuming the Generator
+-----------------------
+
+### Via bazel
+
+We will provide a `cpp_gapic_library` build rule that will depend on the annotated proto files and output a generated gapic library. This will be similar to the rule that exists for gapic-generator in Java [*here*](https://github.com/googleapis/gapic-generator/blob/master/rules_gapic/java/java_gapic.bzl#L139) or Go [*here*](https://github.com/googleapis/gapic-generator/blob/master/rules_gapic/go/go_gapic.bzl#L98).
+See [*go/gapic-bazel-extensions*](https://goto.google.com/gapic-bazel-extensions) for more detail about exposing generation (as well as testing generated libraries and generating packaging) as bazel rules.
+
+### Via protoc plugin
+
+Users can call protoc directly and specify a built gapic-generator-cpp plugin binary. We will defer publishing built binaries that users can download until the generator reaches a post-alpha state, at which time we will re-review.
+
+Implementation
+--------------
+
+The GAPIC generator will implement the protobuf [*CodeGenerator*](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/code_generator.h#L66) interface. Where possible, all logic will be implemented as part of the [*Generate*](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/code_generator.h#L82) method.
+
+The only exception to this is processing metadata annotation information, which may be stored in another protobuf file from the one currently being generated. This will be preprocessed in the [*GenerateAll*](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/code_generator.h#L98) method, and made available to the Generate method. If metadata annotation information is inconsistent across files, the generator will exit with an error.
+
+### Generate Method
+
+The generator will make use of the protobuf [*io::Printer*](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/io/printer.h#L181) object to write files. The printer provides simple templating functionality by accepting a `std::string` template and a set of variables, performs variable substitution on the template, and outputs the result. Unlike more advanced templating languages such as Jinja2, it does not support complex [*control structures*](http://jinja.pocoo.org/docs/2.10/templates/#list-of-control-structures) such as looping. Where loops are necessary (such as over the RPCs in a service) they must be implemented in code. This makes separating the templates from the data model much more difficult than in (for example) gapic-generator-python.
+
+We extract information from the file descriptor and store it in a `std::map<std::string, std::string>` object suitable for use with `io::Printer`. This map is mutable and is passed to methods that iterate over elements of the descriptor, update the map with data from the descriptor, and render templates.
+
+Sample Generation
+-----------------
+
+The generator will support in-code method samples as a GA requirement, but we will delay their implementation until post-alpha. The generator will also support standalone samples, implementation timeline TBD but likely prioritized after in-code samples. We will work with the Samplegen team to ensure we can support both use cases, and cover the full range of sample specification.
+
+The google-cloud-cpp repository contains [*standalone samples*](https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/bigtable/examples) that are compilable and testable, and that also contain annotations that allow them to be [*linked in to documentation*](https://googleapis.github.io/google-cloud-cpp/0.6.0/bigtable/bigtable-hello-world.html). We can follow this model to support documentation and testing of samples.
+
+Testing and CI
+--------------
+
+We will use Kokoro as our CI system. We will integrate with [*GAPIC Showcase*](https://github.com/googleapis/gapic-showcase) to test feature coverage. For example, to use GAPIC Showcase to test paginated methods, we can generate a Showcase API Echo service client and call the [*PagedExpand*](https://github.com/googleapis/gapic-showcase/blob/master/schema/echo.proto#L82) method to verify that our pagination code works as expected. Calls will be made against a local in-memory Showcase API server.
+
+Documentation
+-------------
+
+We will use doxygen, [*similar to google-cloud-cpp*](https://googleapis.github.io/google-cloud-cpp/0.6.0/bigtable/index.html), hosted at https://googleapis.github.io/gapic-generator-cpp.
+
+References
+==========
+- [*https://github.com/googleapis/google-cloud-cpp*](https://github.com/googleapis/google-cloud-cpp)

--- a/docs/LRO_DESIGN.md
+++ b/docs/LRO_DESIGN.md
@@ -1,0 +1,572 @@
+# 'C++ GAPIC LongRunning Operation Design Doc' #
+
+*dovs@google.com*
+
+## Overview
+========
+
+This document is a proposal for how C++ GAPIC generated client libraries will interact with API methods that return google.longrunning.Operation. It covers the 'synchronous' interface exposed to users of the client library and the underlying architecture and mechanisms.
+
+This design is heavily based on the `TableAdmin::SnapshotTable` method from the BigTable client library.
+
+**Note:** although the user visible surface in this document is asynchronous, a distinction is made between it and the future asynchronous method variants generated clients will provide for all methods. These asynchronous methods will rely on a user-injected completion queue that depends on user defined execution mechanisms, e.g. a thread pool or executor. Many of the details required for asynchronous methods are not finalized and fall outside the scope of this document.
+
+In addition to the 'synchronous' long running operation methods described in this doc, there will also be corresponding 'asynchronous' long running operation methods that use the same infrastructure as other asynchronous client methods.
+
+## Background
+==========
+
+A common pattern for API methods that may take a long time to complete (where 'long time' can be anywhere from seconds to days) is to return an instance of `google.longrunning.Operation`, which contains a unique, server provided name; a flag indicating whether the operation is completed; and a union of the concrete return message and an error status.
+
+A separate Operations service exposes methods that use operation names. The most important methods for the purposes of this document is GetOperation, which takes a message using the name of an existing, uncompleted operation and returns a new `google::longrunning::Operation` object with the same name. This new operation may be in a completed state, in which case its result is usable by the client.
+
+These semantics mean that the normal method of client interaction is to poll the operations service until the desired operation has completed successfully or failed.
+
+## Exposed primitive types
+
+## PollingPolicy interface
+
+The PollingPolicy interface is a primitive used to construct a polling loop.
+
+### Interface:
+```cpp
+class PollingPolicy {
+ public:
+  virtual ~PollingPolicy() = default;
+  virtual std::unique_ptr<PollingPolicy>; clone() = 0;
+  virtual void Setup(gax::CallContext&) = 0;
+  virtual bool IsExhausted() = 0;
+  virtual bool IsPermanentFailure(gax::Status const&) = 0;
+  virtual std::chrono::milliseconds WaitPeriod() = 0;
+};
+```
+------------------------------------------------------------
+
+### Default implementation:
+
+```cpp
+template<typename Retry = LimitedTimeRetryPeriod,
+         typename Backoff = ExponentialBackoffPolicy>
+class GenericPollingPolicy : public PollingPolicy {
+ public:
+  GenericPollingPolicy(Retry retry, Backoff backoff);
+  // May provide additional constructors from a defaults-wrapping dumb struct.
+  // Wraps methods from retry and backoff to fulfil interface.
+  };
+```
+------------------------------------------------------------------------------
+
+## `gax::Operation<Response, Metadata>` object
+-----------------------------------------------
+
+This interface provides a thin wrapper over the Operation message type with these addenda:
+
+-   The response and metadata types are strong; the types are obtained from proto annotations and reified by the GAPIC generator.
+
+-   Calls to the Operations service, e.g. GetOperation and DeleteOperation, are wrapped by methods of gax::Operation.
+
+The Operation class is move constructable but not copy constructable or default constructable. It has at least one constructor that is hidden from the user and is used by internal code.
+
+### `gax::Operation` interface:
+
+```cpp
+template<typename ResultType, typename MetadataType>
+class Operation final { 
+ public:
+ Operation(std::shared_ptr<OperationsStub> stub, google::longrunning::Operation op);
+ Operation(Operation&& other) = default; 
+ Operation() = delete;
+ Operation(Operation const&) = delete;
+ 
+ gax::StatusOr<ResultType> 
+ RunPollLoop(PollingPolicy const& polling_policy = DefaultPollingPolicy(), 
+             std::function<void(MetadataType const&)> metadata_func = nullptr); 
+   
+ std::string const& Name() const; // Returns the name assigned by the remote service.
+ 
+ bool Done() const; // Indicates whether the operation has completed.
+ void Cancel(); // Best effort attempt to cancel the remote operation.
+ void Delete(); // Informs the service that the client is no longer
+                // interested in the result.
+   
+ MetadataType const& Metadata() const; // Returns a reference to the metadata
+                                       // from the most recent poll.
+                                       // **Note:** this does not currently consider
+                                       // the possibility that the metadata failed
+                                       // to update correctly, either due to type
+                                       // mismatch or other reasons.
+
+ gax::Status Update(); // Queries the service and gets 
+                       // the most recent result of the operation.
+ 
+ gax::StatusOr<ResultType> Result(); // Returns the end result of the operation.
+                                     // Calling Result() if !Operation::done()
+                                     // returns a Status with code kUnknown. 
+ };
+ static_assert(std::is_move_constructable<Operation>::value);
+ static_assert(!std::is_default_constructable<Operation>::value);
+ static_assert(!std::is_copy_constructable<Operation>::value);
+```
+
+## `gax::OperationsStub` abstract class
+----------------------------------
+
+If the client has at least one LRO, its generated GAPIC stub becomes a child of the OperationsStub abstract class. The `gax::OperationsStub` class is abstract and uninstantiable but provides default, UNIMPLEMENTED status returning definitions for GetOperation, DeleteOperation, and CancelOperation.
+
+The GAPIC generator provides overrides for these methods in the generated default stub class.
+
+### Proposed OperationsStub:
+```cpp
+namespace gax {
+class OperationsStub {
+  virtual ~OperationsStub() = 0;
+ 
+  virtual grpc::Status
+  GetOperation(gax::CallContext& context,
+               google::longrunning::GetOpertaionRequest const &request,
+               google::longrunning::Operation *response) {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "GetOperation is not implemented");
+  }
+  
+  virtual grpc::Status
+  DeleteOperation(gax::CallContext& context,
+                  google::longrunning::DeleteOpertaionRequest const &request,
+                  google::longrunning::Empty *response) {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "DeleteOperation is not implemented");
+  }
+  
+  virtual grpc::Status
+  
+  CancelOperation(gax::CallContext& context,
+                  google::longrunning::CancelOpertaionRequest const &request,
+                  google::longrunning::Empty *response) {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED,
+                        "CancelOperation is not implemented");
+  }
+};
+
+
+inline OperationsStub::~OperationsStub() {}
+  
+}
+```
+
+### Changes to generated GAPIC abstract client:
+
+```
+class LibraryServiceStub : public OperationsStub {
+  // No changes in interface or method implementations. 
+};
+```
+
+### Changes to generated GAPIC default concrete client:
+  
+```
+class DefaultLibraryServiceStub : public LibraryServiceStub {
+  grpc::Status
+  GetOperation(gax::CallContext& context,
+               google::longrunning::GetOpertaionRequest const &request,
+               google::longrunning::Operation *response) override {
+  // Do whatever the other generated overrides do.
+  }
+};
+```
+
+## Changes to existing user visible surfaces
+=========================================
+
+### GAPIC generated client Stub
+---------------------------
+
+The generated abstract Stub class for each GAPIC client will be modified to extend the `gax::OperationsStub` abstract class and will no longer need to provide its own pure virtual destructor.
+
+For clients that have LRO methods, the default concrete Stub class will be augmented to provide `GetOperation`, `CreateOperation`, and `DeleteOperation` methods that issue gRPC calls in a manner similar to other overrides.
+
+### GAPIC generated client
+----------------------
+
+The GAPIC client will gain two methods for interacting with the long-running API.
+
+The GAPIC client will also gain a factory function template that returns instances of `gax::Operation`. This function will take a name describing an in-flight operation and an optional polling policy. This may be useful if a user initiates operations from one process but wants to poll for operation completion in another process.
+
+Example:
+
+```cpp
+class LibraryService final {
+  public:
+  
+  // Other methods
+  // Proposed implementation elided.
+  
+  gax::StatusOr<gax::Operation<Book, GetBigBookMetadata>>
+  GetBigBookOperation(Book const& request,
+  PollingPolicy const& pp = DefaultPollingPolicy());
+  
+  // Proposed implementation elided.
+  std::future<gax::StatusOr<Book>>
+  GetBigBookFuture(Book const& request,
+  PollingPolicy const& pp = DefaultPollingPolicy());
+  
+  template<typename ResultType, typename MetadataType>
+  Operation<ResultType, MetadataType>
+  TryOperation(std::string name, PollingPolicy const& pp = DefaultPollingPolicy()) {
+    google::longrunning::Operation op;
+    op.set_name(name);
+    return Operation<ResultType, MetadataType>(operations_stub_, std::move(op), pp);
+  }
+  };
+```
+
+### User profiles and corresponding interfaces
+==========================================
+
+The design for client methods that use `google::longrunning::Operation`
+recognizes three broad user profiles:
+-   Users who want the simplest, most direct interface, as close as possible to a normal synchronous method call.
+-   Users who want complete control over low level details like polling and metadata.
+-   Middle-ground users who want the client to handle polling, do not want to block waiting for the result, and may want to use operation metadata.
+
+The example API method used below is LibraryService.GetBigBook, with concrete response type Book and concrete metadata type GetBigBookMetadata.
+
+```protobuf
+service LibraryService {
+  rpc GetBigBook(GetBigBookRequest) returns google.longrunning.Operation {
+  option (google.longrunning.operation_info) = {
+    response_type: "Book"
+    metadata_type: "GetBigBookMetadata"
+    };
+  }
+}
+```
+
+### Exposed methods from the client:
+
+```
+gax::StatusOr<gax::Operation<Book, GetBigBookMetadata>>
+  GetBigBookOperation(GetBookRequest const&);
+  google::cloud::future<gax::StatusOr<Book>>
+  GetBigBook(GetBookRequest const&,
+  std::function<void(GetBigBookMetadata const&)> = nullptr);
+```
+
+### Raw `gax::Operation`
+------------------
+
+These users want to implement their own custom polling logic or manage the concurrency of the operation on their own. To allow this, we allow them to operate on `gax::Operation` directly.
+
+The GAPIC client will provide method variants that return `gax::StatusOr<gax::Operation<ResultType, MetadataType>>`.
+
+#### Example interface:
+
+ ```cpp
+ class LibraryClient final {
+  // other client methods and attributes
+  gax::StatusOr<Operation<Book, GetBigBookMetadata>> GetBigBookOperation(GetBookRequest const&);
+  // other client methods and attributes
+  };
+```
+
+#### Example usage:
+
+```cpp
+auto res = client.GetBigBookOperation(request);
+  
+  if(!res) {
+  // do something
+  return;
+  }
+  
+  gax::Operation<Book, GetBigBookMetadata> operation = *std::move(res);
+  operation.Update();
+  
+  if (!operation.Done()) {
+    if (justOnce) {
+      operation.Cancel();
+      return;
+    } else if (dontCare) {
+      operation.Delete();
+      return;
+  }
+  
+  operation.Update();
+  GetBigBookMetadata const& metadata = operation.Metadata();
+  std::cout << "Operation metadata =" << metadata << std::endl;
+  }
+  
+  // Assume that operation is done now for the sake of this example.
+  gax::StatusOr<Book> result = std::move(operation).Result();
+```
+
+#### Possible implementation of GetBigBookOperation:
+
+```cpp
+gax::StatusOr<gax::Operation<Book, GetBigBookMetadata>>
+  GetBigBookOperation(GetBookRequest const& request,
+  PollingPolicy const& polling_policy = DefaultPollingPolicy()) {
+  google::longrunning::Operation op;
+  // Engage in normal, synchronous rpc retry and backoff using stub_->GetBigBook()
+  // Details are elided.
+  return gax::Operation<Book, GetBigBookMetadata>(operations_stub_,
+                                                  std::move(op),
+                                                  polling_policy);
+  }
+```
+
+### `std::future<StatusOr<Response>>`
+
+The users who chose to operate on `std::future<StatusOr<Response>>` do not want to perform their own polling but also do not want to block the current thread unconditionally. They may also wish to interact with operation metadata, possibly to update a progress meter or for logging purposes.
+
+#### Possible implementation:
+
+  
+```cpp
+std::future<gax::StatusOr<Book>> GetBigBook(
+  GetBookRequest const& request,
+  PollingPolicy const& polling_policy = DefaultPollingPolicy(),
+  std::function<void(GetBigBookMetadata const &)> handle_metadata = nullptr) {
+  StatusOr<gax::Operation<Book, GetBigBookMetadata>> opStat = GetBigBookOperation(request, polling_policy);
+  
+  if (!opStat) {
+    std::promise<gax::StatusOr<Book>> status_promise;
+    status_promise.set_value(std::move(opStat).Status());
+    return status_promise.get_future();  
+  }
+  
+  auto launch_policy = bool(handle_metadata) ? std::launch::async : std::launch::deferred;
+  
+  // **Note:** the capture semantics below are almost certainly wrong.
+  // Operation is not copyable, and C++11 doesn't provide native move capture.
+  // There are workarounds: one is to make the copy constructor private and just
+  // copy it here.
+  return std::async(launch_policy, [opStat, handle_metadata]() {
+    return opStat.RunPollLoop(polling_policy, std::move(handle_metadata));
+  });
+  
+  }
+```
+
+#### Example usage:
+
+  
+```cpp
+  std::future<gax::StatusOr<Book>> fut = client.GetBigBookFuture(request);
+  
+  // Do other useful work
+  auto result = fut.wait();
+  
+  std::atomic_uint8_t percent_complete;
+  
+  std::future<gax::StatusOr<Book>> fut2 = client.GetBigBookFuture(request2,
+    // This lambda is an optional parameter.
+   [&percent_complete] (GetBigBookMetadata const& metadata){
+   percent_complete.store(metadata.progress_percent()); });
+
+  // Do other work, use percent_update in another thread to update a progress bar
+  auto result2 = fut.wait();
+```
+
+### Launch policy
+
+Once the initial rpc is invoked, the operation runs on the backend service without requiring additional work by the client. The only purpose of the polling loop is to check for a result and optionally to view operational metadata. As a result, in the case where metadata manipulation is not required, the deferred launch policy conserves system resources and preserves semantics.
+
+If the user needs to manipulate operation metadata, the async launch policy is preferable so that metadata updates are continual.
+
+See [*https://en.cppreference.com/w/cpp/thread/launch*](https://en.cppreference.com/w/cpp/thread/launch) and Effective Modern C++: Item 36[^2] for details on launch policy.
+
+### StatusOr<Response>
+------------------------
+
+This interface is isomorphic to other unary, synchronous API methods. The calling thread blocks waiting for the result, which may take a long time to be available.
+
+E.g.
+
+```cpp
+  StatusOr<Book> result = client.GetBigBookSync(request);
+```
+
+This is functionally equivalent to, and will probably be implemented with,
+```cpp
+  StatusOr<Book> GetBigBookSync(GetBookRequest const& request) {
+  auto fut = client.GetBigBook(request);
+  return fut.wait();
+  }
+```
+
+**Note:** Given the extreme simplicity of the implementation, this interface may not be implemented by GAPIC but instead left as an exercise to the user.
+
+#### Detailed design
+===============
+
+### `gax::Operation`
+--------------
+
+```cpp
+template <typename ResultType, typename MetadataType>
+class Operation final {
+public:
+
+// The real constructor isn't really for general use, but can't think of a
+// good way to hide it and let generated clients call the constructor.
+
+Operation(std::shared_ptr<OperationsStub> stub,
+          google::longrunning::Operation op,
+          PollingPolicy const &polling_policy)
+  : stub_(std::move(stub)), op_(std::move(op)),
+    polling_policy_(polling_policy.clone()) {}
+
+Operation() = delete;
+Operation(Operation const &) = delete;
+Operation(Operation &&) = default;
+
+bool Done() { return op_.done(); }
+
+gax::StatusOr<ResultType> Result() {
+  if (!op_.done()) {
+    return gax::Status(gax::StatusCode::kUnknown,
+                       "operation has not completed=" + op_.name());
+  }
+
+  if (op_.has_error()) {
+    return gax::Status(static_cast<gax::StatusCode>(op_.error().code()),
+                       op_.error().code().message());
+  }
+
+  auto const& any = op_.response();
+  if (!any.Is<ResultType>()) {
+    return gax::Status(gax::StatusCode::kUnknown,
+                       "invalid result in operation=" + operation.name());
+  }
+
+  ResultType result;
+  any.UnpackTo<ResultType>(&result);
+  return result;
+}
+
+gax::Status Update() {
+  if (!done()) {
+    google::longrunning::GetOperationRequest getOpReq;
+    getOpReq.set_name(op_.name());
+    gax::CallContext context;
+    return stub_->GetOperation(&context, getOpReq, &op_);
+    } else if (op_.has_error()) {
+      return gax::Status(static_cast<gax::StatusCode>(op_.error().code()),
+                         op_.error().message());
+    } else {
+    // Default ctor is kOk
+    return gax::Status;
+    }
+}
+
+MetadataType const& Metadata() const {
+  auto const& any = op_.metadata();
+  if (any.Is<MetadataType>()) {
+    any.UnpackTo<MetadataType>(&md_);
+  } else {
+    md_ = MetadataType();
+  }
+
+  return md_;
+}
+
+void Cancel() {
+  google::longrunning::CancelOperationRequest canOpReq;
+  google::protobuf::Empty empty;
+  canOpReq.set_name(op_.name());
+  gax::CallContext context;
+  stub_->CancelOperation(&context, canOpReq, &empty);
+}
+
+void Delete() {
+  google::longrunning::DeleteOperationRequest delOpReq;
+  google::protobuf::Empty empty;
+  delOpReq.set_name(op_.name());
+  gax::CallContext context;
+  stub_->DeleteOperation(&context, delOpReq, &empty);
+}
+```
+
+### Polling loop
+
+```cpp
+gax::StatusOr<ResponseType>
+RunPollLoop(PollingPolicy const& polling_policy = DefaultPollingPolicy(),
+            std::function<void(MetadataType const&)> metadata_func = nullptr) {
+  auto pp = polling_policy.clone();  
+  while (true) {
+    auto status = Update(*pp);
+    if (metadata_func) {
+      metadata_func(Metadata());
+    }
+  
+  if (pp->IsPermanentFailure(status)) {
+    return status;
+  }
+  
+  if (Done()) {
+    return Result();
+  }
+  
+  if (pp->IsExhausted()) {
+    return gax::Status(gax::StatusCode::kDeadlineExceded,
+                       "polling timed out for operation=" + Name());
+  }
+  
+  auto delay = pp->WaitPeriod();
+  std::this_thread::sleep_for(delay);
+  }
+  
+}
+```
+
+Open questions
+==============
+
+Customization and exposure of PollingPolicy
+-------------------------------------------
+
+The expected wait time for an operation to complete is extremely method specific and may vary wildly even for a single method. An auto-generated default, either client-wide or method specific, is unlikely to be useful. Similarly, the utility of an injected client-wide PollingPolicy is limited.
+
+### Initial API call error vs. polling error
+
+Interacting with raw gax::Operation gives potentially useful information on failure: whether the failure happened during the initial call to the API, or whether it happened during polling. This nuance is lost if the user wants to use the future returning variant provided by the GAPIC client.
+
+Is it reasonable to elide this distinction in the future-returning interface?
+
+Design Alternatives
+===================
+
+Standalone OperationsStub
+-------------------------
+
+This was the original design proposal but was superceded by the `OperationsStub` base class in light of the evolving design of `gax::CallContext` and implementing method retry via decoration.
+
+The `OperationsStub` type is independent of the GAPIC stub. It is stored as an additional attribute of LRO owning clients. The base OperationsStub class is instantiable and returns UNIMPLEMENTED statuses for all its methods. Gax also owns a default implementation that issues gRPC calls.
+
+Instead of making `OperationsStub` an injected parameter to the GAPIC client constructor, the GAPIC stub is given a factory method that returns `std::unique_ptr<OperationsStub>`. This lets users who subclass the GAPIC stub to also customize OperationsStub while giving them the option of relying on the default implementation.
+
+This alternative was abandoned because it adds yet another customization point, which is user-unfriendly, and the GAPIC stub factory method injection mechanism was admittedly a hack.
+
+The status quo (OperationsStub is a base class for GAPIC stubs) has the following tradeoffs verses a standalone type:
+
+**Pros:**
+-   Solves injection problem cleanly and removes the need for a factory method.
+-   Gives the user a single point of customization instead of two. This is attractive if the user wants to provide custom gGRPC stub semantics (e.g. channel affinity), use an alternative transport (e.g. Stubby or json/REST), or add decorators for logging or other purposes.
+-   Conceptually cleaner: the fact that the Operations service is distinct from the Client service is an implementation detail.
+-   The gax::Operation class remains agnostic to the concrete type of the stub passed to it in the constructor.
+    -   A previous design alternative added another template parameter to Operation which was used to qualify the type of the stub.
+
+**Cons:**
+-   Tightly couples the Operations methods to the same channel and gRPC stubs (or similar for alternative transports) as the GAPIC stub.
+    -   This may make it difficult to interact with the Operations service for an API if it ever has a different URL from the primary service.
+-   Decoration is less important for Operations methods.=
+    -   Logging and OpenCensus support make sense.
+    -   Duplicate request removal, client side caching, and customized retry do not.
+
+References
+==========
+
+[*https://cloud.google.com/apis/design/design\_patterns*](https://cloud.google.com/apis/design/design_patterns)
+[*https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto*](https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto)
+[*https://en.cppreference.com/w/cpp/thread/future*](https://en.cppreference.com/w/cpp/thread/future)

--- a/docs/LRO_DESIGN.md
+++ b/docs/LRO_DESIGN.md
@@ -63,7 +63,7 @@ This interface provides a thin wrapper over the Operation message type with thes
 
 -   The response and metadata types are strong; the types are obtained from proto annotations and reified by the GAPIC generator.
 
--   Calls to the Operations service, e.g. GetOperation and DeleteOperation, are wrapped by methods of gax::Operation.
+-   Calls to the Operations service, e.g. GetOperation and DeleteOperation, are wrapped by methods of `gax::Operation`.
 
 The Operation class is move constructable but not copy constructable or default constructable. It has at least one constructor that is hidden from the user and is used by internal code.
 

--- a/docs/PAGINATION.md
+++ b/docs/PAGINATION.md
@@ -134,7 +134,7 @@ using ElementAccessor =
 };
 ```
 
-`Pages<ElementType, PageType>`
+`Pages<ElementType, PageType>` - Already implemented, left here for historical purposes
 ----------------------------------
 
 Workhorse structure that engages in rpcs.
@@ -144,8 +144,6 @@ Workhorse structure that engages in rpcs.
 For the `Pages` class, access to the GAPIC stub is necessary in order to retrieve the next page in the sequence, and storing a pointer to it in the Pages struct is necessary to preserve the C++ iterator interface.
 
 In the generated client code, the GAPIC stub will be hidden in the injected `get_next_page` closure.
-
-[Stalled pull request for Pages](https://github.com/googleapis/gapic-generator-cpp/pull/55)
 
 ```cpp
 // Note: we either need to store the accessor function in the Pages struct and

--- a/docs/PAGINATION.md
+++ b/docs/PAGINATION.md
@@ -1,0 +1,262 @@
+# C++ GAPIC Paginated Method Interface Design Doc
+
+
+*dovs@google.com*
+
+Overview
+========
+
+Supported workflow requirements
+-------------------------------
+
+The following are statements and constraints about providing
+abstractions over paginated API methods.
+
+-   Iterating over the elements within a page requires no additional memory or network trips.
+-   Iterating over pages may require additional space and does require network trips.
+-   There is no point in iterating over elements asynchronously: all elements within a page are available immediately.
+-   Because page-continuation is described using a `next_page_token`, at most one subsequent page can be requested asynchronously due to data dependence.
+-   Users MAY wish to terminate iteration early.
+-   Users MAY wish to view the page token for the next page at any time.
+
+Example client method
+=====================
+
+This client method and associated messages will be used in the examples
+in this document.
+
+```protobuf
+message Book {
+  string name = 1;
+  string author = 2;
+  string title = 3;
+  bool read = 4;
+  enum Rating {
+    GOOD = 0;
+    BAD = 1;
+  }
+
+  Rating rating = 5;
+}
+
+message ListBooksRequest {
+  string name = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+  string filter = 4;
+}
+
+message ListBooksResponse {
+  repeated Book books = 1;
+  string next_page_token = 2;
+}
+
+rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
+  //option (google.api.http) = { get: "/v1/{name=bookShelves/*}/books" };
+}
+```
+
+Terminology
+-----------
+
+In the rest of this document, ListBooksResponse is the 'page type' and Book is the 'element type'. The books field of the ListBooksResponse message is the 'element collection', and in C++ is of the type `google::protobuf::RepeatedPtrField<Book>` (for protobuf primitive types, e.g. integers, the element collection would be of type `google::protobuf::RepeatedField<T>`).
+
+Interfaces
+==========
+
+Instead of directly returning the message type described in the service's proto file paginated API methods will return a `gax::PaginatedResult<ElementType, PageType>`. Other template parameters may be necessary for compile-time attribute access.
+
+The returned object will have four public methods: `begin()` and `end()` that define iterators over ElementType; `next_page_token()` that returns the `next_page_token()` attribute of the current page; and pages() that returns a `gax::Pages<ElementType, PageType>` structure defined below.
+
+The iterator for `PaginatedResult` describes a ForwardRange[^1] over all the elements that would be listed by the API method if it returned a single, enormous page. The corresponding client method allows users to cap the number of pages iterated over.
+
+The `gax::Pages<ElementType, PageType>` structure is a ForwardRange over `PageResult<ElementType, PageType>`, described below. It has three public methods: `begin()`, `end()`, and `pages_seen()`.
+
+The `gax::PageResult<ElementType, PageType>` is a thin wrapper around the page type. It provides four public methods: `begin()` and `end()`, which iterate over elements; `next_page_token()`, which is an accessor for the field of the same name in the page; and `RawPage()`, which returns a constant reference to the wrapped page. This may be necessary for the user if the page contains metadata or other information that does not belong to the individual elements.
+
+These interfaces have overlapping responsibilities but are designed to enable multiple tiers of users. Most users are expected to iterate over elements directly and want a minimal interface over pagination. Some may want more explicit control over the number of pages retrieved from the network or may need to reference additional fields in the page.
+
+Detailed Implementation
+=======================
+
+`PageResult<ElementType, PageType>` - Already implemented, left here for historical purposes
+---------------------------------------
+
+```cpp
+template <typename ElementType, typename PageType>
+class PageResult {
+using ElementAccessor =
+  std::function<::google::protobuf::RepeatedPtrField<ElementType>*(PageType&)>;
+ public:
+  class iterator {
+   public:
+   // Note: this could probably be a random_access_iterator, but
+   // it makes the implementation simpler to only support forward iteration,
+   // and it is arguably more correct to force users to slurp elements into their
+   // own random access container if they want to sort or do anything like that.
+   using iterator_category = std::forward_iterator_tag;
+   using value_type = ElementType;
+   using difference_type = std::ptrdiff_t;
+   using pointer = ElementType*;
+   using reference = ElementType&;
+
+   reference operator*() const { return *current_; }
+   pointer operator->() const { return &(*current_); }
+
+   iterator& operator++() {
+     ++current_;
+     return *this;
+   }
+
+  bool operator==(iterator const& rhs) const { return current_ == rhs.current_; }
+  bool operator!=(iterator const& rhs) const { return !(*this == rhs); }
+
+  iterator(typename ::google::protobuf::RepeatedPtrField<ElementType>::iterator current)
+  : current_(std::move(current)) {}
+
+  typename ::google::protobuf::RepeatedPtrField<ElementType>::iterator current_;
+  };
+
+  PageResult(PageType&& page, ElementAccessor accessor)
+   : page_(std::move(page)),
+     begin_(accessor(page_)->begin()),
+     end_(accessor(page_)->end()) {}
+
+  iterator begin() const { return begin_; }
+  iterator end() const { return end_; }
+  std::string NextPageToken() const { return page_.next_page_token(); }
+  PageType const& RawPage() const { return page_; }
+
+ private:
+  PageType page_;
+  iterator const begin_;
+  iterator const end_;
+};
+```
+
+`Pages<ElementType, PageType>`
+----------------------------------
+
+Workhorse structure that engages in rpcs.
+
+**Note:** the decision to store a pointer the client stub was previously visited in the design doc for C++ GAPIC LRO. This option was contentious at the time and ultimately was not chosen.
+
+For the `Pages` class, access to the GAPIC stub is necessary in order to retrieve the next page in the sequence, and storing a pointer to it in the Pages struct is necessary to preserve the C++ iterator interface.
+
+In the generated client code, the GAPIC stub will be hidden in the injected `get_next_page` closure.
+
+[Stalled pull request for Pages](https://github.com/googleapis/gapic-generator-cpp/pull/55)
+
+```cpp
+// Note: we either need to store the accessor function in the Pages struct and
+// pass it in when making iterators or lift it into a template parameter that
+// gets passed down through the hierarchy.
+// In any case, that's a minor implementation detail that can be hashed out in
+// the design doc or in the PR.
+template <typename ElementType, typename PageType>
+class Pages {
+ using NextPageRetriever = std::function<gax::Status(PageType*)>;
+ using ElementAccessor = std::function<::google::protobuf::RepeatedPtrField<ElementType>*(PageType&)>;
+ public:
+  class iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = PageResult<ElementType, PageType>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = PageResult<ElementType, PageType>*;
+    using reference = PageResult<ElementType, PageType>&;
+
+    reference operator*() const { return *page_result_; }
+    pointer operator->() const { return &(*page_result_); }
+
+    iterator& operator++() {
+      PageType page;
+      // Note: if the rpc fails, the page will be untouched, i.e. will still
+      // be in a default-constructed state and will have no elements in the
+      // element collection.
+      get_next_page_(&page);
+      page_result_ = PageResult<ElementType, PageType>(std::move(page), accessor_);
+      return *this;
+    }
+
+    // Comparing page tokens is as good as we can do.
+    // Anything else requires comparing the raw pages, and protobuf messages
+    // do not define equality operators.
+    bool operator==(iterator const& rhs) const {
+      return page_result_.NextPageToken() == rhs.NextPageToken();
+    }
+
+    bool operator!=(iterator const& rhs) const { return !(*this == rhs); }
+
+    iterator(PageResult<ElementType, PageType>&& page_result,
+             ElementAccessor accessor, NextPageRetriever get_next_page)
+     : page_result_(std::move(page_result)),
+       accessor_(std::move(accessor)),
+       get_next_page_(std::move(get_next_page)) {}
+
+ private:
+  PageResult<ElementType, PageType> page_result_;
+  ElementAccessor accessor_;
+  NextPageRetriever get_next_page_;
+  };
+
+  Pages(ElementAccessor accessor, NextPageRetriever get_next_page)
+   : accessor_(std::move(accessor)),
+     get_next_page_(std::move(get_next_page)) {}
+
+  iterator begin() const {
+   PageType page;
+   // Copying the next-page lambda is necessary to start at the beginning.
+   auto fresh_get_next_page_ = get_next_page_;
+   fresh_get_next_page_(&page);
+   return iterator{std::move(page), accessor_,
+                   std::move(fresh_get_next_page_)};
+  }
+
+  iterator end() const { return iterator{PageType{}, nullptr, nullptr}; }
+
+ private:
+  ElementAccessor accessor_;
+  // Note: be sure to capture the initial page request by value so that calling
+  // begin() multiple times is valid.
+  // This means that whenever get_next_page_ is copied, i.e. whenever the user
+  // calls Pages::begin(), a fresh copy of the initial request gets created,
+  // which means that begin() _really_ starts at the beginning.
+  NextPageRetriever get_next_page_;
+};
+```
+
+`PaginatedResult<ElementType, PageType>`
+--------------------------------------------
+
+**Note:** accessor functors and a get-next-page closure are also necessary template and constructor parameters but are only necessary as implementation details; they do nothing to clarify the interface.
+
+```cpp
+template <typename ElementType, typename PageType> class PaginatedResult {
+  class iterator {
+   public:
+   using iterator_category = std::forward_iterator_tag;
+   using value_type = ElementType;
+   using difference_type = std::ptrdiff_t;
+   using pointer = ElementType *;
+   using reference = ElementType &;
+
+   reference operator*() const;
+   pointer operator->() const;
+   iterator &operator++();
+
+   bool operator==(iterator const &rhs) const;
+   bool operator!=(iterator const &rhs) const;
+  };
+
+  Pages Pages();
+  iterator begin();
+  iterator end();
+  std::string NextPageToken();
+  }
+};
+```
+
+The iterator for PaginatedResult wraps a Pages instance and flattens its iterator and the iterators for the individual pages so that what the user sees is a continuous stream of ElementType objects.
+
+References
+==========

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ This repository contains two subprojects:
 The generator takes APIs specified by protocol buffers, such as those inside Google,
 and generates a client library.
 
+**Note:** this project has been shelved. See [`STATUS.md`](STATUS.md) for the current status of various features and designs.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/). Please note it

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -106,6 +106,9 @@ Helper types and library code exist that support the following features:
 
 ## In progress designs ##
 
+The generator and generated client surface are expected to follow the strictures of Google's [API Improvement Proposals](https://aip.dev/) (AIPs).
+Requirements for client library generators are available [here](https://aip.dev/client-libraries/4210).
+
 The limitations of the generator require little to no design or discussion: they are straightforward feature implementations and conformance to the standard set by the other microgenerators. The serious design decisions relate to the generated surface and gax-owned helper types and library code.
 
 A tentative, verbal decision was made to support asynchronous method variants by providing client methods that return `gax::future<gax::StatusOr<Response>>`.
@@ -117,6 +120,12 @@ No design work has been made to explicitly support any transport besides gRPC.
 
 ## Misc ##
 No benchmarks or leak check tests have been implemented for either gax code or generated client code.
+
+## Feature specific docs ##
+[High level generated surface view](SURFACE.md)
+[High level generator view](GENERATOR.md)
+[Long running operations](LRO_DESIGN.md)
+[Paginated methods](PAGINATION.md)
 
 ## References ##
 [Google Cloud Cpp repository](https://github.com/googleapis/google-cloud-cpp/)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,122 @@
+# C++ GAPIC State of the World #
+dovs@google.com
+
+The C++ GAPIC project is being shelved/handed off as of 2019-05-28. This document is intended to be an infodump describing the current status of the project, intended design decisions and philosophies, lacunae, next steps, and anything else that may be relevant to those resurrecting the project at some point in the future.
+
+**NOTE:** the design docs listed here are maintained on a best effort status. They are meant to illuminate design goals, tradeoffs, and plans, but are NOT maintained as live user or developer documentation. If a design in the code and the docs diverge, the code is authoritative.
+
+## Current Capabilities ##
+
+### Generator ###
+
+The generator can read in a correctly formatted service proto file and emit a compilable surface. It can be invoked in a standalone manner or as a proto plugin.
+There is a bazel rule that builds the generator.
+There is a bazel rule that uses the generator to create and compile client library code. It must be passed the label for the service's proto library 'with info' and the labels for the service's `cc_grpc` and `cc_proto targets` as dependencies.
+E.g.:
+```protobuf
+load("//rules_gapic/cpp:cc_gapic.bzl", "cc_gapic_srcjar", "cc_gapic_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_library_with_info")
+
+proto_library(
+    name = "library_proto",
+    srcs = ["library.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_googleapis//google/api:client_proto"],
+)
+
+proto_library_with_info(
+    name = "library_proto_with_info",
+    deps = [":library_proto"],
+)
+
+cc_proto_library(
+    name = "library_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":library_proto"],
+)
+
+cc_grpc_library(
+    name = "library_cc_grpc",
+    srcs = [":library_proto"],
+    grpc_only = True,
+    deps = [":library_cc_proto"],
+)
+
+cc_gapic_library(
+    name = "library_cc_gapic",
+    src = ":library_proto_with_info",
+    package = "google.example.library.v1",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":library_cc_grpc",
+        ":library_cc_proto",
+    ],
+)
+```
+The two headers for the generated surface, `\*.gapic.h` and `\*_stub.gapic.h`, are exported by the target and are visible at sane include paths in dependent code.
+
+### Generated Client ###
+
+There are two factory functions that return a GAPIC stub; both return a retry stub decorating a 'direct' gRPC invoking stub.
+Assuming the service proto is annotated correctly and credentials have been properly set in the environment, synchronous client methods for unary API calls are generated and can be invoked.
+
+### Gax ###
+
+Helper types and library code exist that support the following features:
+* Paginated methods
+* Long running operations
+* Idempotent method retry
+* Custom retry and backoff policies
+* Setting custom per-call gRPC metadata
+
+## Current Limitations ##
+
+### Generator ###
+
+* The generator does not validate the service proto file and does not generate the errors expected by the config validator.
+* The generator does not detect long running operations.
+* The generator does not detect paginated methods.
+* The generator does not create self-contained, compilable samples.
+* The generator does not create tests for any part of the generated client.
+* The generator does not create standalone Bazel or CMake build files for compiling the client.
+* The generator does not annotate the generated client with doxygen comments.
+* The generator currently assumes no methods are idempotent.
+
+### Generated Client ###
+
+* There is no mechanism for configuring the service endpoint via the generated GAPIC stub factory functions.
+* Long running operations:
+    * Clients with long running methods do not have `gax::OperationsClient` returning factory methods.
+    * Client methods that correspond to long running API methods do not return `gax::Operation` instances.
+    * There is no `gax::future<gax::StatusOr<Response>>` returning method variant.
+* No code is generated to support streaming API methods.
+* No asynchronous method variants are generated.
+* Both the client class and the abstract GAPIC stub (and the hidden, concrete, default GAPIC stub classes) live in the global namespace.
+* Minimal support for non-gRPC transports.
+* Support for anything besides default credentials and authentication is non-existent.
+
+### Gax ###
+
+* No supporting types or library routines exist supporting asynchronous method variants.
+* The intended asynchronous primitives are intended to come from Abseil or to be stolen from the Cloud C++ repository.
+* The LRO retry loop is not implemented as it relies on asynchronous primitives not yet in the repository.
+* No supporting types or library routines exist supporting streaming methods.
+* The PaginatedResponse template class, tying together Pages and PageResult, is unimplemented.
+
+## In progress designs ##
+
+The limitations of the generator require little to no design or discussion: they are straightforward feature implementations and conformance to the standard set by the other microgenerators. The serious design decisions relate to the generated surface and gax-owned helper types and library code.
+
+A tentative, verbal decision was made to support asynchronous method variants by providing client methods that return `gax::future<gax::StatusOr<Response>>`.
+The transition of idiomatic asynchronous gRPC from completion-queues to callbacks may adjust this decision, but this is unlikely.
+
+No decision was made on this front, but the idea was raised that, since abstracting gRPC away from the implementation of asynchronous method variants and streaming methods may be non-trivial, these methods may only be supported in a child class of the 'vanilla' generated client. The vanilla client therefore remains transport agnostic without forcing an onerous abstraction.
+No design work has been done to support streaming methods.
+No design work has been made to explicitly support any transport besides gRPC.
+
+## Misc ##
+No benchmarks or leak check tests have been implemented for either gax code or generated client code.
+
+## References ##
+[Google Cloud Cpp repository](https://github.com/googleapis/google-cloud-cpp/)

--- a/docs/SURFACE.md
+++ b/docs/SURFACE.md
@@ -1,0 +1,219 @@
+# C++ GAPIC Surface Design Review
+
+*Authors: michaelbausor@google.com, vam@google.com, dovs@google.com*
+
+Objective
+=========
+
+Describe the design of the new C++ GAPIC generated surface for approval
+by the ACTools and Cloud C++ teams. This document covers the **initial**
+design of the **generated client surface**. See [`GENERATOR.md`](GENERATOR.md) for a description of the generator.
+
+As the generator matures to beta and eventually GA, we expect that
+decisions in this document may be revisited - especially decisions about which GAPIC features to support. This document is intended to describe the requirements for the initial, **alpha-quality** generated surface only, and as such we prefer to exclude features now, with the possibility of introducing them in future.
+
+Background
+==========
+
+ACTools creates client library generators for multiple languages, and is now adding support for C++.
+
+Design
+======
+
+Compatibility
+-------------
+
+We will support the google-cloud-cpp repository as our first and primary customer. Therefore, our generated code will aim to support C++11 along with the [*same set*](https://github.com/googleapis/google-cloud-cpp/tree/master#requirements) of compilers, build tools, dependency versions, and platforms.
+
+Generated clients will **\*not\*** throw exceptions, making them compatible with code that is compiled without exception support.
+
+Dependencies
+------------
+
+The generated clients will depend on gax-cpp, which is the runtime library that supports the generated code. This library is also owned and developed by ACTools, and exists primarily to support the generated code.
+
+The generated clients will also depend on protobuf, gRPC and absl. We will attempt to minimize the exposure of gRPC and absl in our public interfaces. Cases where these dependencies may need to be exposed directly to users are:
+- `absl::StatusOr<T>`, which we will use as a return type once it becomes available.
+
+The GAPIC stub is intended to hide `gRPC::Status` and `gRPC::ClientContext` behind gax owned types.
+
+Convergence
+-----------
+
+We intend to make the generator available inside google3, and allow generated code to be consumed inside google3 via blaze rules. To that end, both the generator and the generated code will follow [*Google C++ style*](https://google.github.io/styleguide/cppguide.html), and attempt to minimize external dependencies that could prevent easy integration into google3.
+
+Generated Clients
+-----------------
+
+Each protobuf service definition in the API will be mapped to a client class. Each client class will have a "`<service>_client.gapic.h`" and a "`<service>_client.gapic.cc`" file. Users will need to include the "`<service>_client.gapic.h`" file. So APIs defining multiple services will generate a separate client class for each service. If a single proto file contains multiple services, we will generate a client class (and corresponding ".gapic.h" and ".gapic.cc" file) for each service.
+
+The generated client class will be similar in many respects to the existing `bigtable::noex::Table` or `bigtable::noex::InstanceAdmin` classes in google-cloud-cpp:
+-   It will need to be passed a Stub object at construction time (this will be the rough equivalent of `bigtable::DataClient` or `bigtable::InstanceAdminClient`)
+-   It can optionally be passed Policy objects that will configure retries, backoff, metadata policy.
+-   It will be moveable but (unlike InstanceAdmin class) not copy constructible.
+    -   The internal Stub will be held as a `shared_ptr`
+    -   Other internal state will be held by `unique_ptrs`
+-   The Stub will be an interface that provides a thin wrapper around the generated grpc StubInterface for the service. Because it is an interface, it will be:
+    -   Mockable for testing
+    -   Possible place for injecting stub/channel pooling behaviour
+    -   Possible in future to implement support for non-gRPC transports
+- The design of the stub is detailed in a separate document.
+
+Example client:
+```cpp
+class GreeterClient {
+ public:
+  // ...
+  GreeterClient(std::shared_ptr<GreeterStub> stub);
+  GreeterClient(std::shared_ptr<GreeterStub> stub, Policies&&... policies);
+  // ...
+ private:
+  std::shared_ptr<GreeterStub> stub_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  // ...
+};
+
+std::shared_ptr<GreeterStub> CreateGreeterStub(/*opts*/);
+```
+
+
+Example usage:
+
+```cpp
+GreeterClient client(CreateGreeterStub());
+```
+
+Each client will have at least one method for each rpc defined in the service, which will have the same name as the rpc (with correct casing).
+
+### Client Policies
+
+We will use Policy objects to configure clients at construction time, directly similar to [*google-cloud-cpp Bigtable*](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/bigtable/instance_admin.h#L55). We will define Policy objects very similar to e.g. [*RPCRetryPolicy*](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/bigtable/rpc_retry_policy.h#L64), with one change to the signatures of the Setup and ShouldRetry (renamed from OnFailure) methods:
+
+```cpp
+class RPCRetryPolicy {
+ public:
+  virtual void PrepareContext(gax::CallContext& context) const = 0;
+  virtual bool ShouldRetry(gax::CallContext& context, gax::Status const& status) = 0;
+};
+```
+
+This change is to:
+- Avoid exposing `grpc::ClientContext` and `grpc::Status` in the policy interface.
+- Provide additional information about the RPC to the policy object via `gax::CallContext`. This allows:
+    -  Default retry behaviour to differ between idempotent and non-idempotent methods (by providing info about idempotency via `gax::CallContext`)
+    -   Users can implement retry/backoff policies that differentiate per-method (by using method name info available in `gax::CallContext`) if needed.
+
+In addition to RPCRetryPolicy, we will support BackoffPolicy with similar modifications.
+
+### Auth
+
+The client will use `grpc::GoogleDefaultCredentials()` by default. We will
+allow users to configure auth in the client constructor.
+
+### Transport and generated GAPIC Stub
+
+The client will use gRPC as the default transport. While we may want to
+add support for additional transports in future, at this time we do not
+have a concrete plan to support them. Indeed, if grpc-fallback support
+is required, it may be gRPC that provides that support rather than GAPIC.
+
+### Unary Methods
+
+**Alpha**: we will generate a single synchronous method that accepts a
+request and returns a `gax::StatusOr<Response>`.
+```cpp
+using pb = google::example::library::v1;
+gax::StatusOr<pb::Book> CreateBook(pb::CreateBookRequest const& request);
+```
+
+**Post alpha**: design support for method overloads to allow per-call
+configuration by users, particularly for:
+
+-   Retries
+
+-   Extracting gRPC metadata
+
+**Post alpha**: Expose async versions of unary methods. Two possible alternatives that we would consider: returning `std::future`, or accepting `std::function` (which is used by the gRPC experimental async interface).
+
+The preferred interface is returning a future for the following reasons:
+- Futures are composable using monads, which meshes well with `StatusOr`.
+- Futures allow `select` like design patterns and polling.
+
+```cpp
+// Example using std::future
+std::future<gax::StatusOr<pb::Book>> AsyncCreateBook(pb::CreateBookRequest const& request);
+
+// Example mirroring gRPC experimental async interface
+void AsyncCreateBook(pb::CreateBookRequest const& request
+                     std::function<void(gax::StatusOr<pb::Book>)>);
+```
+**Post alpha**: Generate any additional method signatures configured in proto annotations as overloads. These move the responsibility of interacting with protobuf from the user to the client method for commonly set message fields. The information necessary to generate these variants comes in via proto annotations.
+
+### Paginated Methods
+
+See [`PAGINATION.md`](PAGINATION.md) for a detailed design of paginated methods.
+
+### LRO
+
+See [`LRO_DESIGN.md`](LRO_DESIGN.md) for a detailed design of long-running methods.
+
+### Streaming Methods
+
+**Alpha**: we will generate a single method that matches the signature of the gRPC streaming interface.
+
+**Post alpha**: potentially design support wrappers around streaming methods. For example, expose server streaming methods as iterators as per [*ReadRows*](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/bigtable/row_reader.h) from google-cloud-cpp.
+
+### Retries
+
+**Alpha:**
+
+The client will default to the following retry behaviour:
+- For **idempotent unary** methods (google.api.http annotation is GET):   - Retry codes: UNAVAILABLE, ABORTED, UNKNOWN
+    - Backoff: Reasonable defaults. Follow [*implementation*](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/bigtable/rpc_backoff_policy.h#L44) in google-cloud-cpp.
+- For **non-idempotent unary** methods (google.api.http annotation missing or not GET):
+    - ~~Retry codes: UNAVAILABLE~~
+    - ~~Backoff: Reasonable defaults. Follow [*implementation*](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/bigtable/rpc_backoff_policy.h#L44) in google-cloud-cpp.~~
+    -   No retries
+-   For **streaming** methods:
+    -   No retries
+
+We will allow users to specify retry and backoff policies in the `RetryStub` constructor and DefaultStub factory.
+
+**Post alpha**: Add support for per-call retry and backoff
+configuration.
+
+Post-alpha
+----------
+
+The generated clients will support the following GAPIC features, but we intend to delay their implementation until **after** the surface reaches an alpha state:
+- Routing headers
+- Method flattening
+- In-code samples
+
+Unsupported features
+--------------------
+
+At this time, we do **not** intend to support the following GAPIC
+features:
+- Resource names
+
+Packaging generation
+--------------------
+
+**Alpha**: No packaging generation.
+
+**Post Alpha**: We will generate minimal cmake files to allow generated clients to be compiled, and to run any generated tests. We will **\*not\*** try to generate complex packaging suitable for publishing generated clients. Allow packaging generation to be controlled via protoc plugin arguments.
+
+Testing Plan
+============
+
+**Alpha**: We will rely on tests in the generator (e.g. unit tests, baseline tests) to ensure correctness of generated output. When generating via bazel rule (instead of using the plugin with protoc), we will support compiling the generated client as a subsequent build step.
+
+**Post alpha**: We will generate unit and smoke tests. When generating via bazel rule, we will support running generated unit tests as a subsequent build step (after compilation). The generated minimal cmake packaging will enable running unit and smoke tests.
+
+**Post alpha**: Full integration with the [*GAPICShowcase*](https://github.com/googleapis/gapic-showcase) test suite.
+- Note: GAPIC Showcase is ACTools' test API and in-memory server, designed for testing the full feature set of generated client libraries.
+
+References
+==========
+-   [*https://github.com/googleapis/google-cloud-cpp*](https://github.com/googleapis/google-cloud-cpp)


### PR DESCRIPTION
Includes state of the world, pagination, LRO, high-level generator, and high level generated surface docs.

These are intended to assist anyone attempting to resurrect C++ GAPIC at a future date by providing insight into design goals, philosophies, and intended directions.

NOTE: the docs are provided AS IS and are not intended to be polished, comprehensive user or developer documentation. If the code and the docs disagree on some detail, the code is correct.