### PR TITLE
testing: add gax CMake files and Docker image for e2e test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.5)
+
+project(gapic-generator CXX)
+
+# Configure the compiler options, we will be using C++11 features.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+include(FindGMockWithTargets)
+
+# Get the destination directories based on the GNU recommendations.
+include(GNUInstallDirs)
+
+add_subdirectory(gax)

--- a/ci/kokoro/docker/e2e/CMakeLists.txt
+++ b/ci/kokoro/docker/e2e/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(google-cloud-cpp-spanner-gapic PUBLIC
 )
 
 add_executable(gapic-generator-e2e
-  spanner-e2e.cc
+  spanner_e2e.cc
 )
 
 target_link_libraries(gapic-generator-e2e PUBLIC

--- a/ci/kokoro/docker/e2e/CMakeLists.txt
+++ b/ci/kokoro/docker/e2e/CMakeLists.txt
@@ -1,0 +1,57 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.5)
+
+project(gapic-generator-e2e CXX)
+
+# Configure the compiler options, we will be using C++11 features.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(googleapis REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(gax REQUIRED)
+
+add_library(google-cloud-cpp-spanner-gapic
+        google/spanner/admin/instance/v1/instance_admin.gapic.cc
+        google/spanner/admin/instance/v1/instance_admin.gapic.h
+        google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.cc
+        google/spanner/admin/instance/v1/instance_admin_stub.gapic.h
+        google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h
+        google/spanner/admin/instance/v1/spanner_instance_admin.pb.h
+        google/spanner/admin/instance/v1/spanner_instance_admin.pb.cc
+        google/spanner/admin/instance/v1/instance_admin_stub.gapic.cc
+)
+
+target_include_directories(
+        google-cloud-cpp-spanner-gapic
+        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+
+target_link_libraries(google-cloud-cpp-spanner-gapic PUBLIC
+  gax
+  googleapis-c++::api_annotations_protos
+  googleapis-c++::longrunning_operations_protos
+  googleapis-c++::rpc_status_protos
+  googleapis-c++::iam_v1_iam_policy_protos
+)
+
+add_executable(gapic-generator-e2e
+  spanner-e2e.cc
+)
+
+target_link_libraries(gapic-generator-e2e PUBLIC
+	              google-cloud-cpp-spanner-gapic)

--- a/ci/kokoro/docker/e2e/Dockerfile
+++ b/ci/kokoro/docker/e2e/Dockerfile
@@ -1,0 +1,152 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:18.04
+
+# Dependencies
+RUN \
+  apt-get update && \
+  apt-get -y install \
+          autoconf \
+          build-essential \
+          clang-tidy \
+          cmake \
+          curl \
+          gcc \
+          git-core \
+          golang \
+          g++ \
+          libtool \
+          libssl-dev \
+          make \
+          pkg-config \
+          wget \
+          vim \
+          zip \
+          zlib1g-dev
+
+# Build directory
+RUN mkdir -p /build && \
+    chmod 0755 /build
+
+WORKDIR /build
+
+# Install c-ares
+RUN \
+  wget -q https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz && \
+  tar -xf cares-1_15_0.tar.gz && \
+  cd c-ares-cares-1_15_0 && \
+  mkdir build && cd build && \
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+  make install && \
+  ldconfig
+
+# Install protobuf
+RUN \
+  wget -q https://github.com/google/protobuf/archive/v3.11.2.tar.gz && \
+  tar -xf v3.11.2.tar.gz && \
+  cd protobuf-3.11.2/cmake && \
+  cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+
+# Install gRPC and abseil
+RUN \
+  git clone https://github.com/grpc/grpc.git && \
+  cd grpc/ && \
+  git checkout v1.26.0 && \
+  git submodule update --init && \
+  mkdir -p cmake/build && \
+  cd cmake/build && \
+  cmake ../.. \
+    -DgRPC_CARES_PROVIDER=package \
+    -DgRPC_PROTOBUF_PROVIDER=package \
+    -DgRPC_SSL_PROVIDER=package \
+    -DgRPC_ZLIB_PROVIDER=package \
+    -DgRPC_INSTALL=on && \
+  CONFIG=dbg make -j ${NCPU} && \
+  CONFIG=dbg make install && \
+  cd /build/grpc/third_party/abseil-cpp && \
+  mkdir -p build && \
+  cd build && \
+  cmake .. && \
+  make -j ${NCPU} && \
+  make install
+
+# Install cpp-cmakefiles
+RUN \
+  wget -q \
+       https://github.com/googleapis/cpp-cmakefiles/archive/v0.2.1.tar.gz && \
+  tar zxvf v0.2.1.tar.gz && \
+  cd cpp-cmakefiles-0.2.1 && \
+  cmake -H. -Bcmake-out && \
+  cmake --build cmake-out -- -j ${NCPU:-4} && \
+  cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+  ldconfig
+
+# Install GTest
+RUN \
+    wget -q \
+         https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. \
+          -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+
+# Install gax
+COPY . /build/gapic-generator-cpp/
+RUN \
+    cd /build/gapic-generator-cpp && \
+    cmake -DBUILD_SHARED_LIBS=on -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    (cd cmake-out; ctest) && \
+    cmake --build cmake-out --target install && \
+    ldconfig
+
+# Install bazel
+RUN /build/gapic-generator-cpp/ci/install-bazel.sh linux
+
+# Build gapic plugin
+RUN \
+    cd /build/gapic-generator-cpp && \
+    /root/bin/bazel build //...
+
+# Use the newer googleapis repo for default_host option
+RUN \
+    git clone https://github.com/googleapis/googleapis
+
+# Run protoc with all the plugin
+ENV GOOGLEAPIS_PATH=/build/googleapis
+RUN \
+protoc --proto_path=${GOOGLEAPIS_PATH} \
+           --cpp_out=/build/gapic-generator-cpp/ci/kokoro/docker/e2e \
+           --grpc_out=/build/gapic-generator-cpp/ci/kokoro/docker/e2e \
+           --cpp_gapic_out=/build/gapic-generator-cpp/ci/kokoro/docker/e2e \
+           --plugin=protoc-gen-grpc=/usr/local/bin/grpc_cpp_plugin \
+           --plugin=protoc-gen-cpp_gapic=/build/gapic-generator-cpp/bazel-bin/generator/protoc-gen-cpp_gapic \
+           ${GOOGLEAPIS_PATH}/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+
+# Compile the generated files
+RUN \
+    cd /build/gapic-generator-cpp/ci/kokoro/docker/e2e && \
+    cmake -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/docker/e2e/Dockerfile
+++ b/ci/kokoro/docker/e2e/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM ubuntu:18.04
+ARG NCPU=4
 
 # Dependencies
 RUN \
@@ -36,10 +37,6 @@ RUN \
           zip \
           zlib1g-dev
 
-# Build directory
-RUN mkdir -p /build && \
-    chmod 0755 /build
-
 WORKDIR /build
 
 # Install c-ares
@@ -47,9 +44,13 @@ RUN \
   wget -q https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz && \
   tar -xf cares-1_15_0.tar.gz && \
   cd c-ares-cares-1_15_0 && \
-  mkdir build && cd build && \
-  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
-  make install && \
+  cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -H. -Bcmake-out && \
+  cmake --build cmake-out -- -j ${NCPU:-4} && \
+  cmake --build cmake-out --target install && \
   ldconfig
 
 # Install protobuf
@@ -63,31 +64,36 @@ RUN \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- && \
     ldconfig
 
-# Install gRPC and abseil
+# Install gRPC
 RUN \
-  git clone https://github.com/grpc/grpc.git && \
-  cd grpc/ && \
-  git checkout v1.26.0 && \
-  git submodule update --init && \
-  mkdir -p cmake/build && \
-  cd cmake/build && \
-  cmake ../.. \
+  wget -q https://github.com/grpc/grpc/archive/v1.26.0.tar.gz && \
+  tar -xf v1.26.0.tar.gz && \
+  cd grpc-1.26.0 && \
+  cmake \
     -DgRPC_CARES_PROVIDER=package \
     -DgRPC_PROTOBUF_PROVIDER=package \
     -DgRPC_SSL_PROVIDER=package \
     -DgRPC_ZLIB_PROVIDER=package \
-    -DgRPC_INSTALL=on && \
-  CONFIG=dbg make -j ${NCPU} && \
-  CONFIG=dbg make install && \
-  cd /build/grpc/third_party/abseil-cpp && \
-  mkdir -p build && \
-  cd build && \
-  cmake .. && \
-  make -j ${NCPU} && \
-  make install
+    -DgRPC_INSTALL=on \
+    -H. -Bcmake-out && \
+  cd cmake-out && \
+  CONFIG=dbg make -j ${NCPU:-4} && \
+  CONFIG=dbg make install
+
+# Install abseil
+RUN \
+  wget -q https://github.com/abseil/abseil-cpp/archive/20190808.tar.gz && \
+  tar -xf 20190808.tar.gz && \
+  cd abseil-cpp-20190808 && \
+  cmake \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+  cmake --build cmake-out -- -j ${NCPU:-4} && \
+  cmake --build cmake-out --target install && \
+  ldconfig
 
 # Install cpp-cmakefiles
 RUN \
@@ -95,9 +101,11 @@ RUN \
        https://github.com/googleapis/cpp-cmakefiles/archive/v0.2.1.tar.gz && \
   tar zxvf v0.2.1.tar.gz && \
   cd cpp-cmakefiles-0.2.1 && \
-  cmake -H. -Bcmake-out && \
+  cmake \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
   cmake --build cmake-out -- -j ${NCPU:-4} && \
-  cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+  cmake --build cmake-out --target install && \
   ldconfig
 
 # Install GTest
@@ -106,8 +114,10 @@ RUN \
          https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
     tar -xf release-1.10.0.tar.gz && \
     cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. \
-          -Bcmake-out && \
+    cmake \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DBUILD_SHARED_LIBS=yes \
+          -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -116,7 +126,9 @@ RUN \
 COPY . /build/gapic-generator-cpp/
 RUN \
     cd /build/gapic-generator-cpp && \
-    cmake -DBUILD_SHARED_LIBS=on -H. -Bcmake-out && \
+    cmake \
+          -DBUILD_SHARED_LIBS=on \
+          -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     (cd cmake-out; ctest) && \
     cmake --build cmake-out --target install && \

--- a/ci/kokoro/docker/e2e/spanner-e2e.cc
+++ b/ci/kokoro/docker/e2e/spanner-e2e.cc
@@ -1,0 +1,28 @@
+#include <grpc++/grpc++.h>
+#include "google/spanner/admin/instance/v1/instance_admin.gapic.h"
+
+using ::google::spanner::admin::instance::v1::ListInstanceConfigsRequest;
+
+int main() {
+  auto creds = grpc::GoogleDefaultCredentials();
+  auto stub = CreateInstanceAdminStub(creds);
+  InstanceAdmin client(std::move(stub));
+  ListInstanceConfigsRequest request;
+  if (const char* project_id = std::getenv("TEST_PROJECT_ID")) {
+    std::string proj = "projects/";
+    request.set_parent(proj + project_id);
+  } else {
+    throw std::runtime_error("Please set TEST_PROJECT_ID env");
+  }
+  auto result = client.ListInstanceConfigs(request);
+  if (!result) {
+    throw std::runtime_error(result.status().message());
+  }
+  auto& configs = *result->mutable_instance_configs();
+  int count = 0;
+  for (auto const& config : configs) {
+    ++count;
+    std::cout << "Instance config [" << count << "]:\n"
+	      << config.DebugString() << "\n";
+  }
+}

--- a/ci/kokoro/docker/e2e/spanner_e2e.cc
+++ b/ci/kokoro/docker/e2e/spanner_e2e.cc
@@ -1,4 +1,18 @@
-#include <grpc++/grpc++.h>
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpcpp/grpcpp.h>
 #include "google/spanner/admin/instance/v1/instance_admin.gapic.h"
 
 using ::google::spanner::admin::instance::v1::ListInstanceConfigsRequest;
@@ -8,11 +22,11 @@ int main() {
   auto stub = CreateInstanceAdminStub(creds);
   InstanceAdmin client(std::move(stub));
   ListInstanceConfigsRequest request;
-  if (const char* project_id = std::getenv("TEST_PROJECT_ID")) {
+  if (const char* project_id = std::getenv("GOOGLE_CLOUD_PROJECT")) {
     std::string proj = "projects/";
     request.set_parent(proj + project_id);
   } else {
-    throw std::runtime_error("Please set TEST_PROJECT_ID env");
+    throw std::runtime_error("Please set GOOGLE_CLOUD_PROJECT env");
   }
   auto result = client.ListInstanceConfigs(request);
   if (!result) {

--- a/ci/kokoro/docker/e2e/spanner_e2e.cc
+++ b/ci/kokoro/docker/e2e/spanner_e2e.cc
@@ -18,9 +18,7 @@
 using ::google::spanner::admin::instance::v1::ListInstanceConfigsRequest;
 
 int main() {
-  auto creds = grpc::GoogleDefaultCredentials();
-  auto stub = CreateInstanceAdminStub(creds);
-  InstanceAdmin client(std::move(stub));
+  InstanceAdmin client(CreateInstanceAdminStub());
   ListInstanceConfigsRequest request;
   if (const char* project_id = std::getenv("GOOGLE_CLOUD_PROJECT")) {
     std::string proj = "projects/";

--- a/ci/kokoro/docker/run_e2e_test.sh
+++ b/ci/kokoro/docker/run_e2e_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+  readonly PROJECT_ROOT
+fi
+
+echo "================================================================"
+echo "Change working directory to project root $(date)."
+cd "${PROJECT_ROOT}"
+
+if [[ -n "${PROJECT_ID:-}" ]]; then
+  DOCKER_IMAGE_PREFIX="gcr.io/${PROJECT_ID}/gapic-generator"
+else
+  # We want a prefix that works when running interactively, so it must be a
+  # (syntactically) valid project id, this works.
+  DOCKER_IMAGE_PREFIX="gcr.io/cloud-cpp-reserved/gapic-generator"
+fi
+readonly DOCKER_IMAGE_PREFIX
+
+# First build the Docker image
+readonly IMAGE="${DOCKER_IMAGE_PREFIX}/e2e-ubuntu-18.04"
+
+echo "================================================================"
+echo "Building a Docker image $(date)."
+docker build -f "${PROJECT_ROOT}/ci/kokoro/docker/e2e/Dockerfile" . \
+  -t "${IMAGE}"
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" \
+  && -n "${TEST_PROJECT_ID:-}" ]]; then
+  echo "================================================================"
+  echo "Executing the binary $(date)."
+  # Run the binary
+  docker run --rm \
+    -v "${GOOGLE_APPLICATION_CREDENTIALS}:/credentials.json" \
+    -e "GOOGLE_APPLICATION_CREDENTIALS=/credentials.json" \
+    -e "TEST_PROJECT_ID=${TEST_PROJECT_ID}" \
+    "${IMAGE}" \
+    bash -c "cd /build/gapic-generator-cpp/ci/kokoro/docker/e2e && cmake-out/gapic-generator-e2e"
+else
+  echo "================================================================"
+  echo -n "Set GOOGLE_APPLICATION_CREDENTIALS and TEST_PROJECT_ID"
+  echo " environment variables to run the binary."
+  echo "Skip executing binary $(date)."
+fi

--- a/cmake/FindGMockWithTargets.cmake
+++ b/cmake/FindGMockWithTargets.cmake
@@ -1,0 +1,146 @@
+# ~~~
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# GTest always requires thread support.
+find_package(Threads REQUIRED)
+
+# When GTest is compiled with CMake, it exports GTest::gtest, GTest::gmock,
+# GTest::gtest_main and GTest::gmock_main as link targets. On the other hand,
+# the standard CMake module to discover GTest, it exports GTest::GTest, and does
+# not export GTest::gmock.
+#
+# In this file we try to normalize the situation to the packages defined in the
+# source.  Not perfect, but better than the mess we have otherwise.
+
+function (gapic_generator_create_googletest_aliases)
+    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
+    # targets for the googletest libraries (not gmock), and with a name that is
+    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
+    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
+    add_library(GTest_gtest INTERFACE)
+    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
+    add_library(GTest_gtest_main INTERFACE)
+    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
+    add_library(GTest::gtest ALIAS GTest_gtest)
+    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
+endfunction ()
+
+function (gapic_generator_gmock_library_import_location target lib)
+    find_library(_library_release ${lib})
+    find_library(_library_debug ${lib}d)
+
+    if ("${_library_debug}" MATCHES "-NOTFOUND" AND "${_library_release}"
+                                                    MATCHES "-NOTFOUND")
+        message(FATAL_ERROR "Cannot find library ${lib} for ${target}.")
+    elseif ("${_library_debug}" MATCHES "-NOTFOUND")
+        set_target_properties(${target} PROPERTIES IMPORTED_LOCATION
+                                                   "${_library_release}")
+    elseif ("${_library_release}" MATCHES "-NOTFOUND")
+        set_target_properties(${target} PROPERTIES IMPORTED_LOCATION
+                                                   "${_library_debug}")
+    else ()
+        set_target_properties(${target} PROPERTIES IMPORTED_LOCATION_DEBUG
+                                                   "${_library_debug}")
+        set_target_properties(${target} PROPERTIES IMPORTED_LOCATION_RELEASE
+                                                   "${_library_release}")
+    endif ()
+endfunction ()
+
+function (gapic_generator_transfer_library_properties target source)
+
+    add_library(${target} IMPORTED UNKNOWN)
+    get_target_property(value ${source} IMPORTED_LOCATION)
+    if (NOT value)
+        get_target_property(value ${source} IMPORTED_LOCATION_DEBUG)
+        if (EXISTS "${value}")
+            set_target_properties(${target} PROPERTIES IMPORTED_LOCATION
+                                                       ${value})
+        endif ()
+        get_target_property(value ${source} IMPORTED_LOCATION_RELEASE)
+        if (EXISTS "${value}")
+            set_target_properties(${target} PROPERTIES IMPORTED_LOCATION
+                                                       ${value})
+        endif ()
+    endif ()
+    foreach (
+        property
+        IMPORTED_LOCATION_DEBUG
+        IMPORTED_LOCATION_RELEASE
+        IMPORTED_CONFIGURATIONS
+        INTERFACE_INCLUDE_DIRECTORIES
+        IMPORTED_LINK_INTERFACE_LIBRARIES
+        IMPORTED_LINK_INTERFACE_LIBRARIES_DEBUG
+        IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE)
+        get_target_property(value ${source} ${property})
+        message("*** ${source} ${property} ${value}")
+        if (value)
+            set_target_properties(${target} PROPERTIES ${property} "${value}")
+        endif ()
+    endforeach ()
+endfunction ()
+
+include(CTest)
+if (TARGET GTest::gmock)
+    # GTest::gmock is already defined, do not define it again.
+elseif (NOT BUILD_TESTING)
+    # Tests are turned off via -DBUILD_TESTING, do not load the googletest or
+    # googlemock dependency.
+else ()
+    # Try to find the config package first. If that is not found
+    find_package(GTest CONFIG QUIET)
+    find_package(GMock CONFIG QUIET)
+    if (NOT GTest_FOUND)
+        find_package(GTest MODULE REQUIRED)
+
+        gapic_generator_create_googletest_aliases()
+
+        # The FindGTest module finds GTest by default, but does not search for
+        # GMock, though they are usually installed together. Define the
+        # GTest::gmock* targets manually.
+        find_path(
+            GMOCK_INCLUDE_DIR gmock/gmock.h
+            HINTS $ENV{GTEST_ROOT}/include ${GTEST_ROOT}/include
+            DOC "The GoogleTest Mocking Library headers")
+        if ("${GMOCK_INCLUDE_DIR}" MATCHES "-NOTFOUND")
+            message(
+                FATAL_ERROR "Cannot find gmock headers ${GMOCK_INCLUDE_DIR}.")
+        endif ()
+        mark_as_advanced(GMOCK_INCLUDE_DIR)
+
+        add_library(GTest::gmock IMPORTED UNKNOWN)
+        gapic_generator_gmock_library_import_location(GTest::gmock gmock)
+        set_target_properties(
+            GTest::gmock
+            PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES
+                       "GTest::GTest;Threads::Threads"
+                       INTERFACE_INCLUDE_DIRECTORIES "${GMOCK_INCLUDE_DIRS}")
+
+        add_library(GTest::gmock_main IMPORTED UNKNOWN)
+        gapic_generator_gmock_library_import_location(GTest::gmock_main
+                                                       gmock_main)
+        set_target_properties(
+            GTest::gmock_main
+            PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES
+                       "GTest::gmock;Threads::Threads"
+                       INTERFACE_INCLUDE_DIRECTORIES "${GMOCK_INCLUDE_DIRS}")
+    endif ()
+
+    if (NOT TARGET GTest::gmock AND TARGET GMock::gmock)
+        gapic_generator_transfer_library_properties(GTest::gmock GMock::gmock)
+        gapic_generator_transfer_library_properties(GTest::gmock_main
+                                                     GMock::gmock_main)
+    endif ()
+endif ()

--- a/cmake/FindGMockWithTargets.cmake
+++ b/cmake/FindGMockWithTargets.cmake
@@ -1,5 +1,5 @@
 # ~~~
-# Copyright 2020 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ elseif (NOT BUILD_TESTING)
     # Tests are turned off via -DBUILD_TESTING, do not load the googletest or
     # googlemock dependency.
 else ()
-    # Try to find the config package first. If that is not found
+    # Try to find the config package first.
     find_package(GTest CONFIG QUIET)
     find_package(GMock CONFIG QUIET)
     if (NOT GTest_FOUND)

--- a/cmake/GapicGeneratorCommon.cmake
+++ b/cmake/GapicGeneratorCommon.cmake
@@ -1,0 +1,28 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+function (gax_install_headers target destination)
+    get_target_property(target_sources ${target} SOURCES)
+    foreach (header ${target_sources})
+        if (NOT "${header}" MATCHES "\\.h$" AND NOT "${header}" MATCHES
+                                                "\\.inc$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" relative "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        install(FILES "${header}" DESTINATION "${destination}/${dir}")
+    endforeach ()
+endfunction ()

--- a/gax/CMakeLists.txt
+++ b/gax/CMakeLists.txt
@@ -1,0 +1,122 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+set(GAX_VERSION_MAJOR 0)
+set(GAX_VERSION_MINOR 1)
+set(GAX_VERSION_PATCH 0)
+
+string(CONCAT GAX_VERSION
+              "${GAX_VERSION_MAJOR}"
+              "."
+              "${GAX_VERSION_MINOR}"
+              "."
+              "${GAX_VERSION_PATCH}")
+
+include(GapicGeneratorCommon)
+
+find_package(googleapis REQUIRED)
+find_package(gRPC REQUIRED)
+
+add_library(gax
+        backoff_policy.cc
+        backoff_policy.h
+        call_context.cc
+        call_context.h
+        internal/gtest_prod.h
+        internal/invoke_result.h
+        operation.h
+        operations_client.cc
+        operations_client.h
+        operations_stub.cc
+        operations_stub.h
+        pagination.h
+        retry_loop.h
+        retry_policy.h
+        status.cc
+        status.h
+        status_or.h)
+
+target_include_directories(
+        gax
+        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+
+set_target_properties(
+    gax
+    PROPERTIES VERSION ${GAX_VERSION} SOVERSION
+    ${GAX_VERSION_MAJOR})
+
+target_link_libraries(gax PUBLIC googleapis-c++::longrunning_operations_protos)
+
+# Export the CMake targets to make it easy to create configuration files.
+install(EXPORT gax-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gax")
+
+install(
+    TARGETS gax
+    EXPORT gax-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT gax_runtime
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT gax_runtime
+            NAMELINK_SKIP
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT gax_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(
+    TARGETS gax
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT gax_development
+            NAMELINK_ONLY
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT gax_development)
+
+gax_install_headers(gax include/gax)
+
+set(gax_unit_tests
+    backoff_policy_test.cc
+    operations_stub_test.cc
+    operation_test.cc
+    pagination_test.cc
+    retry_loop_test.cc
+    retry_policy_test.cc
+    status_or_test.cc
+    status_test.cc
+)
+
+foreach (fname ${gax_unit_tests})
+        string(REPLACE "/" "_" target ${fname})
+        string(REPLACE ".cc" "" target ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(
+            ${target}
+            PRIVATE gax
+                    GTest::gmock_main GTest::gmock GTest::gtest)
+        if (MSVC)
+            target_compile_options(${target} PRIVATE "/bigobj")
+        endif ()
+        add_test(NAME ${target} COMMAND ${target})
+endforeach ()
+
+# Create and install the CMake configuration files.
+configure_file("config.cmake.in" "gax-config.cmake" @ONLY)
+configure_file("config-version.cmake.in"
+               "gax-config-version.cmake" @ONLY)
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/gax-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/gax-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gax")

--- a/gax/CMakeLists.txt
+++ b/gax/CMakeLists.txt
@@ -30,28 +30,31 @@ include(GapicGeneratorCommon)
 find_package(googleapis REQUIRED)
 find_package(gRPC REQUIRED)
 
+
 add_library(gax
-        backoff_policy.cc
-        backoff_policy.h
-        call_context.cc
-        call_context.h
-        internal/gtest_prod.h
-        internal/invoke_result.h
-        operation.h
-        operations_client.cc
-        operations_client.h
-        operations_stub.cc
-        operations_stub.h
-        pagination.h
-        retry_loop.h
-        retry_policy.h
-        status.cc
-        status.h
-        status_or.h)
+    # cmake-format: sortable
+    backoff_policy.cc
+    backoff_policy.h
+    call_context.cc
+    call_context.h
+    internal/gtest_prod.h
+    internal/invoke_result.h
+    operation.h
+    operations_client.cc
+    operations_client.h
+    operations_stub.cc
+    operations_stub.h
+    pagination.h
+    retry_loop.h
+    retry_policy.h
+    status.cc
+    status.h
+    status_or.h)
 
 target_include_directories(
-        gax
-        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+    gax
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
 
 set_target_properties(
     gax
@@ -62,7 +65,7 @@ target_link_libraries(gax PUBLIC googleapis-c++::longrunning_operations_protos)
 
 # Export the CMake targets to make it easy to create configuration files.
 install(EXPORT gax-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gax")
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gax")
 
 install(
     TARGETS gax
@@ -86,18 +89,19 @@ install(
 
 gax_install_headers(gax include/gax)
 
-set(gax_unit_tests
-    backoff_policy_test.cc
-    operations_stub_test.cc
-    operation_test.cc
-    pagination_test.cc
-    retry_loop_test.cc
-    retry_policy_test.cc
-    status_or_test.cc
-    status_test.cc
-)
-
-foreach (fname ${gax_unit_tests})
+if (BUILD_TESTING)
+    set(gax_unit_tests
+        # cmake-format: sortable
+        backoff_policy_test.cc
+        operations_stub_test.cc
+        operation_test.cc
+        pagination_test.cc
+        retry_loop_test.cc
+        retry_policy_test.cc
+        status_or_test.cc
+        status_test.cc
+    )
+    foreach (fname ${gax_unit_tests})
         string(REPLACE "/" "_" target ${fname})
         string(REPLACE ".cc" "" target ${target})
         add_executable(${target} ${fname})
@@ -109,7 +113,8 @@ foreach (fname ${gax_unit_tests})
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+    endforeach ()
+endif()
 
 # Create and install the CMake configuration files.
 configure_file("config.cmake.in" "gax-config.cmake" @ONLY)

--- a/gax/config-version.cmake.in
+++ b/gax/config-version.cmake.in
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PACKAGE_VERSION @GAX_VERSION@)
+
+# This package has not reached 1.0, there are no compatibility guarantees
+# before then.
+if (@GAX_VERSION_MAJOR@ EQUAL 0)
+    if ("${PACKAGE_FIND_VERSION}" STREQUAL "")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    elseif ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+        set(PACKAGE_VERSION_EXACT TRUE)
+    else ()
+        set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    endif ()
+elseif("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()

--- a/gax/config.cmake.in
+++ b/gax/config.cmake.in
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/gax-targets.cmake")


### PR DESCRIPTION
To run the e2e test, you need to set `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_CLOUD_PROJECT`.

Potentially we can create CMakefiles to the generator itself, but it can be done by another PR.